### PR TITLE
Fixed "Revoke TL" being visible to non-support users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for TrustedLogin Client
 
+## 1.0.1 (2021-09-27)
+
+- Fixed issue where non-support users may see the "Revoke TrustedLogin" admin bar link.
+
 ## 1.0.0 (2021-09-22)
 
 This is the initial production release of TrustedLogin! Thank you to everyone who has worked on the project, including [Hector Kolonas](https://github.com/inztinkt), [Josh Pollock](https://github.com/Shelob9), and [Shawn Hooper](https://github.com/shawnhooper).

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -159,6 +159,18 @@ final class Admin {
 			return;
 		}
 
+		$current_user = wp_get_current_user();
+
+		if ( ! $current_user || ! $current_user->exists() ) {
+			return;
+		}
+
+		$has_expiration = $this->support_user->get_expiration( $current_user );
+
+		if ( ! $has_expiration ) {
+			return;
+		}
+
 		$icon = '<span style="
 			height: 32px;
 			width: 23px;

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,7 +36,7 @@ final class Client {
 	 * @var string The current drop-in file version
 	 * @since 1.0.0
 	 */
-	const VERSION = '1.0.0';
+	const VERSION = '1.0.1';
 
 	/**
 	 * @var Config


### PR DESCRIPTION
Fixed issue where users with all roles assigned to them would see "Revoke TrustedLogin".