### PR TITLE
Allow client to use exact role, not only cloned roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `clone_role` configuration setting to allow the support user to be created with an existing role, rather than a clone of a role
 - Added a `trustedlogin_{ns}_support_role` capability to the cloned support user role in order to better identify that the role is created by TrustedLogin
+- Converted CSS generation to use SCSS mixins to allow easier overrides by themes and plugins
 - Clarified the language surrounding user roles in the Grant Access form
 - Moved the admin toolbar link to next to the "Howdy, {username}" menu
   - Relabeled the link from "Revoke TrustedLogin" to "Revoke Access"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for TrustedLogin Client
 
+## 1.6.0 (TBD)
+
+- Added `clone_role` configuration setting to allow the support user to be created with an existing role, rather than a clone of a role
+- Added a `trustedlogin_{ns}_support_role` capability to the cloned support user role in order to better identify that the role is created by TrustedLogin
+- Clarified the language surrounding user roles in the Grant Access form
+- Moved the admin toolbar link to next to the "Howdy, {username}" menu
+  - Relabeled the link from "Revoke TrustedLogin" to "Revoke Access"
+- Improved user creation flow to prevent errors when creating a user with an existing email address
+- Fixed error when using PHP in strict mode
+
 ## 1.5.1 (2023-04-18)
 
 - Fixed PHP error caused by HEREDOC template formatting in `Form.php`

--- a/client.php
+++ b/client.php
@@ -49,6 +49,7 @@ $config = [
     'webhook' => [
 		'url' => 'https://example.com/webhook',
 		'create_ticket' => true,
+		'debug_data' => true,
 	]
 ];
 $config = new \TrustedLogin\Config( $config );

--- a/client.php
+++ b/client.php
@@ -58,4 +58,17 @@ try {
 	);
 } catch ( \Exception $exception ) {
     error_log( $exception->getMessage() );
+
+	add_action( 'admin_notices', function() use ( $exception ) {
+
+		if( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		?>
+		<div class="notice notice-error">
+			<p><?php echo $exception->getMessage(); ?></p>
+		</div>
+		<?php
+	} );
 }

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -160,10 +160,12 @@ final class Admin {
 
 		$admin_bar->add_menu( array(
 			'id'    => 'tl-' . $this->config->ns() . '-revoke',
-			'title' => $icon . esc_html__( 'Revoke TrustedLogin', 'trustedlogin' ),
+			'title' => $icon . esc_html__( 'Revoke Access', 'trustedlogin' ),
 			'href'  => $this->support_user->get_revoke_url( 'all' ),
+			'parent' => 'top-secondary',
 			'meta'  => array(
 				'class' => 'tl-destroy-session',
+				'title' => esc_html__( 'You are logged in as a support user. Click to permanently revoke access.', 'trustedlogin' ),
 			),
 		) );
 	}

--- a/src/Config.php
+++ b/src/Config.php
@@ -391,15 +391,20 @@ final class Config {
 			return $default;
 		}
 
-		if ( isset( $array[ $prop ] ) ) {
-			$value = $array[ $prop ];
-		} else {
-			$value = $default;
+		// Directly fetch the value if it exists, otherwise use the default.
+		$value = isset( $array[ $prop ] ) ? $array[ $prop ] : $default;
+
+		// Special handling for zero and false.
+		if ( 0 === $value || false === $value ) {
+			return $value;
 		}
 
-		$value_is_zero = 0 === $value;
+		// If the value is empty and a default is provided, use the default.
+		if ( empty( $value ) && null !== $default ) {
+			return $default;
+		}
 
-		return ( empty( $value ) && ! $value_is_zero ) && $default !== null ? $default : $value;
+		return $value;
 	}
 
 	/**

--- a/src/Config.php
+++ b/src/Config.php
@@ -67,6 +67,7 @@ final class Config {
 		'reassign_posts' => true,
 		'require_ssl'    => true,
 		'role'           => 'editor',
+		'clone_role'     => true,
 		'vendor'         => array(
 			'namespace'             => null,
 			'title'                 => null,
@@ -183,11 +184,23 @@ final class Config {
 			}
 		}
 
-		$added_caps = $this->get_setting( 'caps/add', array(), $this->settings );
+		if ( ! empty( $this->settings['clone_role'] ) ) {
+			$added_caps = $this->get_setting( 'caps/add', array(), $this->settings );
 
-		foreach ( SupportRole::$prevented_caps as $invalid_cap ) {
-			if ( array_key_exists( $invalid_cap, $added_caps ) ) {
-				$errors[] = new \WP_Error( 'invalid_configuration', 'TrustedLogin users cannot be allowed to: ' . $invalid_cap );
+			foreach ( SupportRole::$prevented_caps as $invalid_cap ) {
+				if ( array_key_exists( $invalid_cap, $added_caps ) ) {
+					$errors[] = new \WP_Error( 'invalid_configuration', 'TrustedLogin users cannot be allowed to: ' . $invalid_cap );
+				}
+			}
+		} else {
+			$added_caps = $this->get_setting( 'caps/add', array(), $this->settings );
+			$removed_caps = $this->get_setting( 'caps/remove', array(), $this->settings );
+
+			$added_caps = array_filter( $added_caps );
+			$removed_caps = array_filter( $removed_caps );
+
+			if ( ! empty( $added_caps ) || ! empty( $removed_caps ) ) {
+				$errors[] = new \WP_Error( 'invalid_configuration', 'When `clone_role` is disabled, TrustedLogin cannot add or remove capabilities.' );
 			}
 		}
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -495,12 +495,20 @@ final class Form {
 
 		// translators: %s is replaced by the amount of time that the login will be active for (e.g. "1 week")
 		$expire_desc = '<small>' . sprintf( esc_html__( 'Access auto-expires in %s. You may revoke access at any time.', 'trustedlogin' ), human_time_diff( 0, $this->config->get_setting( 'decay' ) ) ) . '</small>';
+
 		$cloned_role = translate_user_role( ucfirst( $this->config->get_setting( 'role' ) ) );
-		if ( $this->config->get_setting( 'caps/add' ) || $this->config->get_setting( 'caps/remove' ) ) {
-			// translators: %s is replaced with the name of the role being cloned (e.g. "Administrator")
-			$roles_summary = sprintf( esc_html__( 'Create a user with a role similar to %s.', 'trustedlogin' ), '<strong>' . $cloned_role . '</strong>' );
-			$roles_summary .= sprintf( '<small class="tl-' . $ns . '-toggle" data-toggle=".tl-' . $ns . '-auth__role-container">%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span></small>', esc_html__( 'View role capabilities', 'trustedlogin' ) );
+
+		if( $this->config->get_setting( 'clone_role' ) ) {
+
+			// translators: %s is replaced with the name of the role (e.g. "Administrator")
+			$roles_summary = sprintf( esc_html__( 'Create a user with a role based on %s.', 'trustedlogin' ), '<strong>' . $cloned_role . '</strong>' );
+
+			if ( $this->config->get_setting( 'caps/add' ) || $this->config->get_setting( 'caps/remove' ) ) {
+				$roles_summary .= sprintf( '<small class="tl-' . $ns . '-toggle" data-toggle=".tl-' . $ns . '-auth__role-container">%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span></small>', esc_html__( 'View modified role capabilities', 'trustedlogin' ) );
+			}
+
 		} else {
+
 			// translators: %s is replaced with the name of the role (e.g. "Administrator")
 			$roles_summary = sprintf( esc_html__( 'Create a user with a role of %s.', 'trustedlogin' ), '<strong>' . $cloned_role . '</strong>' );
 		}

--- a/src/SupportRole.php
+++ b/src/SupportRole.php
@@ -18,6 +18,12 @@ use WP_Error;
 final class SupportRole {
 
 	/**
+	 * @const The capability that is added to the Support Role to indicate that it was created by TrustedLogin.
+	 * @since 1.5.0
+	 */
+	const CAPABILITY_FLAG = 'trustedlogin_{ns}_support_role';
+
+	/**
 	 * @var Config $config
 	 */
 	private $config;
@@ -34,7 +40,7 @@ final class SupportRole {
 	private $role_name;
 
 	/**
-	 * @var array These capabilities will never be allowed for users created by TrustedLogin
+	 * @var array These capabilities will never be allowed for users created by TrustedLogin.
 	 * @since 1.0.0
 	 */
 	static $prevented_caps = array(
@@ -45,6 +51,25 @@ final class SupportRole {
 		'promote_users',
 		'delete_site',
 		'remove_users',
+	);
+
+	/**
+	 * @var array These roles cannot be deleted by TrustedLogin.
+	 * @since 1.5.0
+	 */
+	static $protected_roles = array(
+		'administrator',
+		'editor',
+		'author',
+		'contributor',
+		'subscriber',
+		'wpseo_editor',
+		'wpseo_manager',
+		'shop_manager',
+		'shop_accountant',
+		'shop_worker',
+		'shop_vendor',
+		'customer'
 	);
 
 	/**
@@ -90,7 +115,9 @@ final class SupportRole {
 
 		// If we're not cloning a role, return the existing role name.
 		if ( ! $this->config->get_setting( 'clone_role' ) ) {
-			return (string) $this->config->get_setting( 'role' );
+			$role_name = (string) $this->config->get_setting( 'role' );
+
+			return sanitize_title_with_dashes( $role_name );
 		}
 
 		$default = $this->config->ns() . '-support';
@@ -113,7 +140,7 @@ final class SupportRole {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @return \WP_Role|\WP_Error Pre-existing role, if successful. WP_Error if failure.
+	 * @return \WP_Role|\WP_Error Role, if successful. WP_Error if failure.
 	 */
 	public function get() {
 
@@ -137,6 +164,17 @@ final class SupportRole {
 		}
 
 		return $role;
+	}
+
+	/**
+	 * Returns the custom capability name that will be added to the role to indicate that it was created by TrustedLogin.
+	 *
+	 * @param string $ns The namespace of the vendor.
+	 *
+	 * @return string
+	 */
+	static private function get_capability_flag( $ns ) {
+		return str_replace( '{ns}', $ns, self::CAPABILITY_FLAG );
 	}
 
 	/**
@@ -205,6 +243,12 @@ final class SupportRole {
 			$this
 		);
 
+		/**
+		 * Add a flag to declare that this role was created by TrustedLogin.
+		 * @used-by SupportRole::delete()
+		 */
+		$capabilities[ self::get_capability_flag( $this->config->ns() ) ] = true;
+
 		$new_role = add_role( $new_role_slug, $role_display_name, $capabilities );
 
 		if ( ! $new_role ){
@@ -238,15 +282,33 @@ final class SupportRole {
 	 */
 	public function delete() {
 
-		if ( ! get_role( $this->get_name() ) ) {
+		$role_to_delete = get_role( $this->get_name() );
+
+		if ( ! $role_to_delete ) {
 			return null;
 		}
 
-		// Returns void; no way to tell if successful
+		$capability_flag = self::get_capability_flag( $this->config->ns() );
+
+		// Don't delete roles that weren't created by TrustedLogin.
+		if ( ! $role_to_delete->has_cap( $capability_flag ) ) {
+			$this->logging->log( "Role " . $this->get_name() . " is missing the CAPABILITY_FLAG. It is not possible to determine that it was created by TrustedLogin; it will not be removed.", __METHOD__, 'error' );
+
+			return false;
+		}
+
+		// Sanity check: don't ever, for any reason, delete protected roles.
+		if ( in_array( $this->get_name(), self::$protected_roles ) ) {
+			$this->logging->log( "Role " . $this->get_name() . " is protected and cannot be removed.", __METHOD__, 'error' );
+
+			return false;
+		}
+
+		// Returns void; no way to tell if successful...
 		remove_role( $this->get_name() );
 
+		// So we manually check if it was removed successfully.
 		if( get_role( $this->get_name() ) ) {
-
 			$this->logging->log( "Role " . $this->get_name() . " was not removed successfully.", __METHOD__, 'error' );
 
 			return false;

--- a/src/SupportRole.php
+++ b/src/SupportRole.php
@@ -19,7 +19,7 @@ final class SupportRole {
 
 	/**
 	 * @const The capability that is added to the Support Role to indicate that it was created by TrustedLogin.
-	 * @since 1.5.0
+	 * @since 1.6.0
 	 */
 	const CAPABILITY_FLAG = 'trustedlogin_{ns}_support_role';
 
@@ -55,7 +55,7 @@ final class SupportRole {
 
 	/**
 	 * @var array These roles cannot be deleted by TrustedLogin.
-	 * @since 1.5.0
+	 * @since 1.6.0
 	 */
 	static $protected_roles = array(
 		'administrator',
@@ -138,7 +138,7 @@ final class SupportRole {
 	/**
 	 * Returns the Support Role, creating it if it doesn't already exist.
 	 *
-	 * @since 1.5.0
+	 * @since 1.6.0
 	 *
 	 * @return \WP_Role|\WP_Error Role, if successful. WP_Error if failure.
 	 */

--- a/src/SupportUser.php
+++ b/src/SupportUser.php
@@ -115,7 +115,6 @@ final class SupportUser {
 	public function exists() {
 
 		$args = array(
-			'role'         => $this->role->get_name(),
 			'number'       => 1,
 			'meta_key'     => $this->user_identifier_meta_key,
 			'meta_value'   => '',
@@ -157,7 +156,7 @@ final class SupportUser {
 	}
 
 	/**
-	 * Create the Support User with custom role.
+	 * Create the Support User.
 	 *
 	 * @since 1.0.0
 	 *
@@ -176,19 +175,10 @@ final class SupportUser {
 			return new \WP_Error( 'user_exists', sprintf( 'A user with the User ID %d already exists', $user_id ) );
 		}
 
-		$role_exists = $this->role->create();
+		$role = $this->role->get();
 
-		if ( is_wp_error( $role_exists ) ) {
-
-			$error_output = $role_exists->get_error_message();
-
-			if ( $error_data = $role_exists->get_error_data() ) {
-				$error_output .= ' ' . print_r( $error_data, true );
-			}
-
-			$this->logging->log( $error_output, __METHOD__, 'error' );
-
-			return $role_exists;
+		if ( is_wp_error( $role ) ) {
+			return $role;
 		}
 
 		$user_email = $this->config->get_setting( 'vendor/email' );
@@ -220,7 +210,7 @@ final class SupportUser {
 			'user_login'      => $this->generate_unique_username(),
 			'user_email'      => $user_email,
 			'user_pass'       => Encryption::get_random_hash( $this->logging ),
-			'role'            => $this->role->get_name(),
+			'role'            => $role->name,
 			'display_name'    => $this->config->get_setting( 'vendor/display_name', '' ),
 			'user_registered' => date( 'Y-m-d H:i:s', time() ),
 		);
@@ -379,7 +369,6 @@ final class SupportUser {
 		}
 
 		$args = array(
-			'role'       => $this->role->get_name(),
 			'number'     => 1,
 			'meta_key'   => $this->user_identifier_meta_key,
 			'meta_value' => $user_identifier_hash,
@@ -411,7 +400,7 @@ final class SupportUser {
 	}
 
 	/**
-	 * Get all users with the support role
+	 * Get all users with the support role.
 	 *
 	 * @since 1.0.0
 	 *
@@ -427,7 +416,10 @@ final class SupportUser {
 		}
 
 		$args = array(
-			'role' => $this->role->get_name(),
+			'number'     => - 1,
+			'meta_key'   => $this->user_identifier_meta_key,
+			'meta_compare' => 'EXISTS',
+			'meta_value' => '',
 		);
 
 		$support_users = get_users( $args );


### PR DESCRIPTION
## Merging to `main` Checklist

- [ ] Version number has been bumped [in Client.php](https://github.com/trustedlogin/client/blob/main/src/Client.php#L39)
- [ ] `CHANGELOG.md` has been updated
- [ ] `@since TODO` in docblocks have been updated
- [ ] [Docs](https://trustedlogin.github.io/docs/) have been updated with any changes
- [ ] [Tag the release](https://github.com/trustedlogin/client/releases/new)
