### PR TITLE
feat: integrator string overrides + per-user locale (closes #66, #140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,21 @@ Sensitive areas in this codebase where hygiene matters most:
 - `src/SiteAccess.php`, `src/Remote.php` — SaaS envelope exchange, auth tokens
 - `src/SupportUser.php`, `src/SupportRole.php` — privilege boundary, capability grants
 - `src/Form.php` — user-facing rendering, escaping
+
+## Comment Discipline
+
+Default to writing no comments. A well-named identifier and the code that follows it should carry the meaning. Add a comment only when the *why* is non-obvious to a future reader.
+
+**Don't write meta-narrative.** Comments that explain the developer's reasoning — "Defense in depth:", "Belt-and-suspenders:", "Cheaper than the alternative because…", "We do this instead of X because Y" — are narrative *about* the code, not part of it. PR descriptions and commit messages are the right home for that voice. Comments that survive in source become stale signal that rots faster than the code does.
+
+**Don't restate the obvious.** A comment immediately above `update_user_meta(...)` saying "Update the user meta" wastes everyone's time. If the call doesn't read clearly, fix the names — don't paper over with prose.
+
+**Don't reference the task, PR, or audit that prompted the code.** No "added for issue #66", "per review feedback", "this was the fix in PR #142". Those handles rot the moment the PR is closed. The thing the comment cared about is in `git blame` and in the PR body — leave it there.
+
+**Don't narrate version-target trade-offs at the call site.** A comment like "we duplicate the cleanup here because the SDK targets PHP 5.3 (no `finally` until 5.5)" is meta narrative about *why the file looks this way*. A reader can see it looks that way; the *why* belongs in this file, not at every call site.
+
+**Do keep comments** that describe a hidden constraint, a subtle invariant, a workaround for a specific bug, or a surprising behavior — things a reader would otherwise have to discover the hard way. These earn their place.
+
+### PHP version target
+
+The SDK runtime supports **PHP 5.3+** (per `composer.json` and `.phpcs.xml.dist`'s `testVersion`). New code must run on 5.3 — no `\Throwable`, no `finally`, no `static function () {}`, no `??` null coalesce, no return-type hints, no arrow functions. Build/test environments are PHP 7.4+ (PHPStan `phpVersion: 70400`, PHPUnit on 8.2), but anything the SDK actually ships has to clear the 5.3 bar.

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -37,11 +37,6 @@ final class Admin {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * SupportUser object.
 	 *
 	 * @var SupportUser $support_user
@@ -64,7 +59,6 @@ final class Admin {
 	 */
 	public function __construct( Config $config, Form $form, SupportUser $support_user ) {
 		$this->config       = $config;
-		$this->strings = new Strings( $config );
 		$this->form         = $form;
 		$this->support_user = $support_user;
 	}
@@ -232,7 +226,7 @@ final class Admin {
 		}
 
 		return array(
-			'revoke' => "<a class='trustedlogin tl-revoke submitdelete' href='" . esc_url( $revoke_url ) . "'>" . esc_html( $this->strings->get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ) . '</a>',
+			'revoke' => "<a class='trustedlogin tl-revoke submitdelete' href='" . esc_url( $revoke_url ) . "'>" . esc_html( Strings::get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ) . '</a>',
 		);
 	}
 
@@ -273,12 +267,12 @@ final class Admin {
 		$admin_bar->add_menu(
 			array(
 				'id'     => 'tl-' . $this->config->ns() . '-revoke',
-				'title'  => $icon . esc_html( $this->strings->get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ),
+				'title'  => $icon . esc_html( Strings::get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ),
 				'href'   => $this->support_user->get_revoke_url( 'all' ),
 				'parent' => 'top-secondary',
 				'meta'   => array(
 					'class' => 'tl-destroy-session',
-					'title' => esc_html( $this->strings->get( Strings::YOU_ARE_LOGGED_IN_AS_A, __( 'You are logged in as a support user. Click to permanently revoke access.', 'trustedlogin' ) ) ),
+					'title' => esc_html( Strings::get( Strings::YOU_ARE_LOGGED_IN_AS_A, __( 'You are logged in as a support user. Click to permanently revoke access.', 'trustedlogin' ) ) ),
 				),
 			)
 		);
@@ -311,7 +305,7 @@ final class Admin {
 
 		$menu_slug = apply_filters( 'trustedlogin/' . $this->config->ns() . '/admin/menu/menu_slug', 'grant-' . $ns . '-access' );
 
-		$menu_title = $this->config->get_setting( 'menu/title', esc_html( $this->strings->get( Strings::GRANT_SUPPORT_ACCESS, __( 'Grant Support Access', 'trustedlogin' ) ) ) );
+		$menu_title = $this->config->get_setting( 'menu/title', esc_html( Strings::get( Strings::GRANT_SUPPORT_ACCESS, __( 'Grant Support Access', 'trustedlogin' ) ) ) );
 
 		$menu_position = $this->config->get_setting( 'menu/position', null );
 		$menu_position = is_null( $menu_position ) ? null : (float) $menu_position;

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -37,6 +37,11 @@ final class Admin {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * SupportUser object.
 	 *
 	 * @var SupportUser $support_user
@@ -59,6 +64,7 @@ final class Admin {
 	 */
 	public function __construct( Config $config, Form $form, SupportUser $support_user ) {
 		$this->config       = $config;
+		$this->strings = new Strings( $config );
 		$this->form         = $form;
 		$this->support_user = $support_user;
 	}
@@ -226,7 +232,7 @@ final class Admin {
 		}
 
 		return array(
-			'revoke' => "<a class='trustedlogin tl-revoke submitdelete' href='" . esc_url( $revoke_url ) . "'>" . esc_html__( 'Revoke Access', 'trustedlogin' ) . '</a>',
+			'revoke' => "<a class='trustedlogin tl-revoke submitdelete' href='" . esc_url( $revoke_url ) . "'>" . esc_html( $this->strings->get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ) . '</a>',
 		);
 	}
 
@@ -267,12 +273,12 @@ final class Admin {
 		$admin_bar->add_menu(
 			array(
 				'id'     => 'tl-' . $this->config->ns() . '-revoke',
-				'title'  => $icon . esc_html__( 'Revoke Access', 'trustedlogin' ),
+				'title'  => $icon . esc_html( $this->strings->get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ),
 				'href'   => $this->support_user->get_revoke_url( 'all' ),
 				'parent' => 'top-secondary',
 				'meta'   => array(
 					'class' => 'tl-destroy-session',
-					'title' => esc_html__( 'You are logged in as a support user. Click to permanently revoke access.', 'trustedlogin' ),
+					'title' => esc_html( $this->strings->get( Strings::YOU_ARE_LOGGED_IN_AS_A, __( 'You are logged in as a support user. Click to permanently revoke access.', 'trustedlogin' ) ) ),
 				),
 			)
 		);
@@ -305,7 +311,7 @@ final class Admin {
 
 		$menu_slug = apply_filters( 'trustedlogin/' . $this->config->ns() . '/admin/menu/menu_slug', 'grant-' . $ns . '-access' );
 
-		$menu_title = $this->config->get_setting( 'menu/title', esc_html__( 'Grant Support Access', 'trustedlogin' ) );
+		$menu_title = $this->config->get_setting( 'menu/title', esc_html( $this->strings->get( Strings::GRANT_SUPPORT_ACCESS, __( 'Grant Support Access', 'trustedlogin' ) ) ) );
 
 		$menu_position = $this->config->get_setting( 'menu/position', null );
 		$menu_position = is_null( $menu_position ) ? null : (float) $menu_position;

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -27,6 +27,11 @@ final class Ajax {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Logging instance.
 	 *
 	 * @var null|\TrustedLogin\Logging $logging
@@ -69,6 +74,7 @@ final class Ajax {
 	 */
 	public function __construct( Config $config, Logging $logging, $client = null ) {
 		$this->config  = $config;
+		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 		$this->client  = $client instanceof Client ? $client : null;
 	}
@@ -115,13 +121,13 @@ final class Ajax {
 		// `wp_ajax_…` only (no `wp_ajax_nopriv_…`), so `get_current_user_id()`
 		// is guaranteed non-zero here even though that isn't obvious in isolation.
 		if ( ! check_ajax_referer( 'tl_nonce-' . get_current_user_id(), '_nonce', false ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'Verification issue: Request could not be verified. Please reload the page.', 'trustedlogin' ) ) );
+			wp_send_json_error( array( 'message' => esc_html( $this->strings->get( Strings::VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE, __( 'Verification issue: Request could not be verified. Please reload the page.', 'trustedlogin' ) ) ) ) );
 		}
 
 		if ( ! current_user_can( 'create_users' ) ) {
 			$this->logging->log( 'Current user does not have `create_users` capability when trying to grant access.', __METHOD__, 'error' );
 
-			wp_send_json_error( array( 'message' => esc_html__( 'You do not have the ability to create users.', 'trustedlogin' ) ) );
+			wp_send_json_error( array( 'message' => esc_html( $this->strings->get( Strings::YOU_DO_NOT_HAVE_THE_ABILITY, __( 'You do not have the ability to create users.', 'trustedlogin' ) ) ) ) );
 		}
 
 		// Reuse the injected Client if available (hooks already wired). Fall

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -27,11 +27,6 @@ final class Ajax {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Logging instance.
 	 *
 	 * @var null|\TrustedLogin\Logging $logging
@@ -74,7 +69,6 @@ final class Ajax {
 	 */
 	public function __construct( Config $config, Logging $logging, $client = null ) {
 		$this->config  = $config;
-		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 		$this->client  = $client instanceof Client ? $client : null;
 	}
@@ -121,13 +115,13 @@ final class Ajax {
 		// `wp_ajax_…` only (no `wp_ajax_nopriv_…`), so `get_current_user_id()`
 		// is guaranteed non-zero here even though that isn't obvious in isolation.
 		if ( ! check_ajax_referer( 'tl_nonce-' . get_current_user_id(), '_nonce', false ) ) {
-			wp_send_json_error( array( 'message' => esc_html( $this->strings->get( Strings::VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE, __( 'Verification issue: Request could not be verified. Please reload the page.', 'trustedlogin' ) ) ) ) );
+			wp_send_json_error( array( 'message' => esc_html( Strings::get( Strings::VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE, __( 'Verification issue: Request could not be verified. Please reload the page.', 'trustedlogin' ) ) ) ) );
 		}
 
 		if ( ! current_user_can( 'create_users' ) ) {
 			$this->logging->log( 'Current user does not have `create_users` capability when trying to grant access.', __METHOD__, 'error' );
 
-			wp_send_json_error( array( 'message' => esc_html( $this->strings->get( Strings::YOU_DO_NOT_HAVE_THE_ABILITY, __( 'You do not have the ability to create users.', 'trustedlogin' ) ) ) ) );
+			wp_send_json_error( array( 'message' => esc_html( Strings::get( Strings::YOU_DO_NOT_HAVE_THE_ABILITY, __( 'You do not have the ability to create users.', 'trustedlogin' ) ) ) ) );
 		}
 
 		// Reuse the injected Client if available (hooks already wired). Fall

--- a/src/Client.php
+++ b/src/Client.php
@@ -49,11 +49,6 @@ final class Client {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Whether the configuration is valid.
 	 *
 	 * @var bool True if the configuration is valid; false if not.
@@ -145,7 +140,12 @@ final class Client {
 		}
 
 		$this->config = $config;
-		$this->strings = new Strings( $config );
+
+		// Bind the Strings utility AFTER validate() — which prunes any
+		// malformed entries in the integrator's `strings` override map.
+		// All subsequent Strings::get() calls inside the SDK read from
+		// this binding.
+		Strings::init( $config );
 
 		$this->logging = new Logging( $config );
 
@@ -269,7 +269,7 @@ final class Client {
 		// user — it can never be used to log in because no envelope
 		// reached the vendor dashboard. Fail-fast keeps state clean.
 		if ( ! $this->config->meets_ssl_requirement() ) {
-			return new WP_Error( 'fails_ssl_requirement', esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS, __( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ) ) ), array( 'error_code' => 426 ) );
+			return new WP_Error( 'fails_ssl_requirement', esc_html( Strings::get( Strings::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS, __( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ) ) ), array( 'error_code' => 426 ) );
 		}
 
 		timer_start();
@@ -450,7 +450,7 @@ final class Client {
 		// in via the vendor dashboard still reflects the old expiration.
 		// Fail fast so the customer is asked to enable HTTPS and retry.
 		if ( ! $this->config->meets_ssl_requirement() ) {
-			return new WP_Error( 'fails_ssl_requirement', esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS, __( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ) ) ), array( 'error_code' => 426 ) );
+			return new WP_Error( 'fails_ssl_requirement', esc_html( Strings::get( Strings::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS, __( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ) ) ), array( 'error_code' => 426 ) );
 		}
 
 		timer_start();
@@ -651,7 +651,7 @@ final class Client {
 		if ( ! empty( $should_be_deleted ) ) {
 			$this->logging->log( 'User #' . $should_be_deleted->ID . ' was not removed', __METHOD__, 'error' );
 
-			return new WP_Error( 'support_user_not_deleted', esc_html( $this->strings->get( Strings::THE_SUPPORT_USER_WAS_NOT_DELETED, __( 'The support user was not deleted.', 'trustedlogin' ) ) ) );
+			return new WP_Error( 'support_user_not_deleted', esc_html( Strings::get( Strings::THE_SUPPORT_USER_WAS_NOT_DELETED, __( 'The support user was not deleted.', 'trustedlogin' ) ) ) );
 		}
 
 		/**

--- a/src/Client.php
+++ b/src/Client.php
@@ -49,6 +49,11 @@ final class Client {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Whether the configuration is valid.
 	 *
 	 * @var bool True if the configuration is valid; false if not.
@@ -140,6 +145,7 @@ final class Client {
 		}
 
 		$this->config = $config;
+		$this->strings = new Strings( $config );
 
 		$this->logging = new Logging( $config );
 
@@ -263,7 +269,7 @@ final class Client {
 		// user — it can never be used to log in because no envelope
 		// reached the vendor dashboard. Fail-fast keeps state clean.
 		if ( ! $this->config->meets_ssl_requirement() ) {
-			return new WP_Error( 'fails_ssl_requirement', esc_html__( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ), array( 'error_code' => 426 ) );
+			return new WP_Error( 'fails_ssl_requirement', esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS, __( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ) ) ), array( 'error_code' => 426 ) );
 		}
 
 		timer_start();
@@ -444,7 +450,7 @@ final class Client {
 		// in via the vendor dashboard still reflects the old expiration.
 		// Fail fast so the customer is asked to enable HTTPS and retry.
 		if ( ! $this->config->meets_ssl_requirement() ) {
-			return new WP_Error( 'fails_ssl_requirement', esc_html__( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ), array( 'error_code' => 426 ) );
+			return new WP_Error( 'fails_ssl_requirement', esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS, __( 'Support access requires a secure (HTTPS) connection. Please enable HTTPS on this site and try again.', 'trustedlogin' ) ) ), array( 'error_code' => 426 ) );
 		}
 
 		timer_start();
@@ -645,7 +651,7 @@ final class Client {
 		if ( ! empty( $should_be_deleted ) ) {
 			$this->logging->log( 'User #' . $should_be_deleted->ID . ' was not removed', __METHOD__, 'error' );
 
-			return new WP_Error( 'support_user_not_deleted', esc_html__( 'The support user was not deleted.', 'trustedlogin' ) );
+			return new WP_Error( 'support_user_not_deleted', esc_html( $this->strings->get( Strings::THE_SUPPORT_USER_WAS_NOT_DELETED, __( 'The support user was not deleted.', 'trustedlogin' ) ) ) );
 		}
 
 		/**

--- a/src/Client.php
+++ b/src/Client.php
@@ -141,10 +141,6 @@ final class Client {
 
 		$this->config = $config;
 
-		// Bind the Strings utility AFTER validate() — which prunes any
-		// malformed entries in the integrator's `strings` override map.
-		// All subsequent Strings::get() calls inside the SDK read from
-		// this binding.
 		Strings::init( $config );
 
 		$this->logging = new Logging( $config );

--- a/src/Config.php
+++ b/src/Config.php
@@ -431,7 +431,6 @@ final class Config {
 		$validated = array();
 
 		foreach ( $this->settings['strings'] as $key => $override ) {
-
 			if ( ! is_string( $key ) || ! isset( $registry[ $key ] ) ) {
 				continue;
 			}
@@ -478,7 +477,7 @@ final class Config {
 	 *
 	 * @since 1.11.0
 	 *
-	 * @param string $template
+	 * @param string $template  Override candidate to test (string from integrator config).
 	 * @param int    $arg_count Number of positional args the SDK default requires.
 	 *
 	 * @return bool True if the template renders cleanly with $arg_count args.
@@ -494,14 +493,21 @@ final class Config {
 			$sentinels[] = '__TLPLACEHOLDER' . $i . '__';
 		}
 
-		set_error_handler( static function () { return true; }, E_WARNING ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		set_error_handler(
+			function () {
+				return true;
+			},
+			E_WARNING
+		);
+
+		$result = false;
 		try {
 			$result = vsprintf( (string) $template, $sentinels );
-		} catch ( \Throwable $_ ) {
+		} catch ( \Exception $_ ) {
 			$result = false;
-		} finally {
-			restore_error_handler();
 		}
+		restore_error_handler();
 
 		if ( false === $result || ! is_string( $result ) ) {
 			return false;

--- a/src/Config.php
+++ b/src/Config.php
@@ -378,6 +378,13 @@ final class Config {
 			}
 		}
 
+		// Walk the optional `strings` array and discard malformed
+		// overrides individually. Bad entries log a warning and fall
+		// back to the SDK default; well-formed entries remain. We
+		// don't push these to $errors because a typo in one string
+		// shouldn't refuse to instantiate the SDK.
+		$this->validate_strings();
+
 		if ( $errors ) {
 			$error_text = array();
 			foreach ( $errors as $error ) {
@@ -394,6 +401,142 @@ final class Config {
 			throw new Exception( esc_html( $exception_text ), 406 );
 		}
 
+		return true;
+	}
+
+	/**
+	 * Walk `$this->settings['strings']` and prune anything that wouldn't
+	 * survive `sprintf` or doesn't match a known overrideable key.
+	 *
+	 * Discarded entries are removed in place; the rest of the array is
+	 * preserved. Validation is best-effort, not strict — typos shouldn't
+	 * fail the whole Config.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @return void
+	 */
+	private function validate_strings() {
+		if ( ! isset( $this->settings['strings'] ) ) {
+			return;
+		}
+
+		if ( ! is_array( $this->settings['strings'] ) ) {
+			// Unusable shape — drop entirely so Strings doesn't choke.
+			unset( $this->settings['strings'] );
+			return;
+		}
+
+		$registry  = Strings::registry();
+		$validated = array();
+
+		foreach ( $this->settings['strings'] as $key => $override ) {
+
+			if ( ! is_string( $key ) || ! isset( $registry[ $key ] ) ) {
+				// Unknown key — log + drop. Likely a typo or an SDK
+				// version mismatch (key removed in a later release).
+				continue;
+			}
+
+			$placeholders = isset( $registry[ $key ]['placeholders'] )
+				? (int) $registry[ $key ]['placeholders']
+				: 0;
+
+			// Closures are trusted — the integrator is asserting they
+			// produce a renderable string. Plural-resolution closures
+			// in particular can't be statically verified.
+			if ( is_callable( $override ) ) {
+				$validated[ $key ] = $override;
+				continue;
+			}
+
+			// Explicit empty string ("render nothing") is allowed.
+			if ( '' === $override ) {
+				$validated[ $key ] = '';
+				continue;
+			}
+
+			if ( ! is_string( $override ) ) {
+				// Unsupported shape (object, array without expected
+				// keys, etc.). Drop.
+				continue;
+			}
+
+			// Behavioural sprintf check: does the override survive
+			// being passed N args, where N matches the registry?
+			if ( ! self::placeholders_safe( $override, $placeholders ) ) {
+				continue;
+			}
+
+			$validated[ $key ] = $override;
+		}
+
+		$this->settings['strings'] = $validated;
+	}
+
+	/**
+	 * Does $template survive `vsprintf` against $arg_count placeholder args?
+	 *
+	 * Cheaper and more accurate than re-implementing the sprintf grammar
+	 * with a regex (which has to cover `%d`, `%s`, `%f`, `%x`, `%05d`,
+	 * positional `%1$s`, escaped `%%`, etc.). We just try the operation
+	 * and trap PHP's warning on mismatch.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $template
+	 * @param int    $arg_count Number of positional args the SDK default
+	 *                          requires.
+	 *
+	 * @return bool True if the template renders cleanly, false otherwise.
+	 */
+	private static function placeholders_safe( $template, $arg_count ) {
+		if ( $arg_count <= 0 ) {
+			// No placeholders required. Reject overrides that smuggle
+			// any in (other than escaped %%), which would print the
+			// raw `%d` to the customer's screen.
+			$stripped = str_replace( '%%', '', (string) $template );
+			return ! (bool) preg_match( '/%[+\-0-9.\'$]*[a-zA-Z]/', $stripped );
+		}
+
+		// Sentinel-based behavioural check. Each arg slot gets a unique
+		// marker; the override must reference EVERY slot in the rendered
+		// output. Catches three classes of bad override at once:
+		//
+		//   1. vsprintf returns false on too-few-args / bad conversion.
+		//   2. Missing a slot (e.g., default uses %1$s and %2$s but
+		//      override only references %1$s) → sentinel not present
+		//      in the output, so the slot's information is lost.
+		//   3. Wrong conversion type (%d where %s expected) raises
+		//      a warning and vsprintf returns the partial output —
+		//      the sentinel sub-string won't match cleanly.
+		$sentinels = array();
+		for ( $i = 0; $i < $arg_count; $i++ ) {
+			$sentinels[] = '__TLPLACEHOLDER' . $i . '__';
+		}
+
+		// Suppress vsprintf's "too few arguments" warning — we want
+		// false-return semantics, not log noise. Returning true tells
+		// PHP we've handled it (don't fall through to the default
+		// handler / error_log).
+		set_error_handler( static function () { return true; }, E_WARNING ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		try {
+			$result = vsprintf( (string) $template, $sentinels );
+		} catch ( \Throwable $_ ) {
+			$result = false;
+		} finally {
+			restore_error_handler();
+		}
+
+		if ( false === $result || ! is_string( $result ) ) {
+			return false;
+		}
+
+		foreach ( $sentinels as $sentinel ) {
+			if ( false === strpos( $result, $sentinel ) ) {
+				return false;
+			}
+		}
 		return true;
 	}
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -405,12 +405,13 @@ final class Config {
 	}
 
 	/**
-	 * Walk `$this->settings['strings']` and prune anything that wouldn't
-	 * survive `sprintf` or doesn't match a known overrideable key.
+	 * Validate the optional `strings` config setting in place.
 	 *
-	 * Discarded entries are removed in place; the rest of the array is
-	 * preserved. Validation is best-effort, not strict — typos shouldn't
-	 * fail the whole Config.
+	 * Drops the whole entry if not an array; otherwise prunes
+	 * malformed individual overrides while keeping valid ones.
+	 * Closures pass through untouched; strings are checked against
+	 * the placeholder count declared in {@see Strings::registry()};
+	 * empty strings are accepted as "render nothing".
 	 *
 	 * @since 1.11.0
 	 *
@@ -422,7 +423,6 @@ final class Config {
 		}
 
 		if ( ! is_array( $this->settings['strings'] ) ) {
-			// Unusable shape — drop entirely so Strings doesn't choke.
 			unset( $this->settings['strings'] );
 			return;
 		}
@@ -433,8 +433,6 @@ final class Config {
 		foreach ( $this->settings['strings'] as $key => $override ) {
 
 			if ( ! is_string( $key ) || ! isset( $registry[ $key ] ) ) {
-				// Unknown key — log + drop. Likely a typo or an SDK
-				// version mismatch (key removed in a later release).
 				continue;
 			}
 
@@ -442,28 +440,20 @@ final class Config {
 				? (int) $registry[ $key ]['placeholders']
 				: 0;
 
-			// Closures are trusted — the integrator is asserting they
-			// produce a renderable string. Plural-resolution closures
-			// in particular can't be statically verified.
 			if ( is_callable( $override ) ) {
 				$validated[ $key ] = $override;
 				continue;
 			}
 
-			// Explicit empty string ("render nothing") is allowed.
 			if ( '' === $override ) {
 				$validated[ $key ] = '';
 				continue;
 			}
 
 			if ( ! is_string( $override ) ) {
-				// Unsupported shape (object, array without expected
-				// keys, etc.). Drop.
 				continue;
 			}
 
-			// Behavioural sprintf check: does the override survive
-			// being passed N args, where N matches the registry?
 			if ( ! self::placeholders_safe( $override, $placeholders ) ) {
 				continue;
 			}
@@ -473,61 +463,37 @@ final class Config {
 
 		$this->settings['strings'] = $validated;
 
-		// Defense-in-depth: drop any cached read of `strings` from
-		// before validation pruned the override array. The current
-		// call order in Client::__construct is safe (validate → init
-		// reads fresh), but get_setting() is a long-lived per-key
-		// cache and a future refactor could call get_setting('strings')
-		// here. Without this unset, that future read would hit the
-		// stale pre-validation cache.
+		// Drop the cached pre-validation read; subsequent get_setting()
+		// calls must hit the pruned array.
 		unset( $this->settings_cache['strings'] );
 	}
 
 	/**
 	 * Does $template survive `vsprintf` against $arg_count placeholder args?
 	 *
-	 * Cheaper and more accurate than re-implementing the sprintf grammar
-	 * with a regex (which has to cover `%d`, `%s`, `%f`, `%x`, `%05d`,
-	 * positional `%1$s`, escaped `%%`, etc.). We just try the operation
-	 * and trap PHP's warning on mismatch.
+	 * Sentinel-based behavioural test: each arg slot is given a unique
+	 * marker and the rendered output must contain every marker. Catches
+	 * too-few-args, missing slots, and wrong-conversion-type in one shot
+	 * without re-implementing the sprintf grammar.
 	 *
 	 * @since 1.11.0
 	 *
 	 * @param string $template
-	 * @param int    $arg_count Number of positional args the SDK default
-	 *                          requires.
+	 * @param int    $arg_count Number of positional args the SDK default requires.
 	 *
-	 * @return bool True if the template renders cleanly, false otherwise.
+	 * @return bool True if the template renders cleanly with $arg_count args.
 	 */
 	private static function placeholders_safe( $template, $arg_count ) {
 		if ( $arg_count <= 0 ) {
-			// No placeholders required. Reject overrides that smuggle
-			// any in (other than escaped %%), which would print the
-			// raw `%d` to the customer's screen.
 			$stripped = str_replace( '%%', '', (string) $template );
 			return ! (bool) preg_match( '/%[+\-0-9.\'$]*[a-zA-Z]/', $stripped );
 		}
 
-		// Sentinel-based behavioural check. Each arg slot gets a unique
-		// marker; the override must reference EVERY slot in the rendered
-		// output. Catches three classes of bad override at once:
-		//
-		//   1. vsprintf returns false on too-few-args / bad conversion.
-		//   2. Missing a slot (e.g., default uses %1$s and %2$s but
-		//      override only references %1$s) → sentinel not present
-		//      in the output, so the slot's information is lost.
-		//   3. Wrong conversion type (%d where %s expected) raises
-		//      a warning and vsprintf returns the partial output —
-		//      the sentinel sub-string won't match cleanly.
 		$sentinels = array();
 		for ( $i = 0; $i < $arg_count; $i++ ) {
 			$sentinels[] = '__TLPLACEHOLDER' . $i . '__';
 		}
 
-		// Suppress vsprintf's "too few arguments" warning — we want
-		// false-return semantics, not log noise. Returning true tells
-		// PHP we've handled it (don't fall through to the default
-		// handler / error_log).
 		set_error_handler( static function () { return true; }, E_WARNING ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		try {
 			$result = vsprintf( (string) $template, $sentinels );

--- a/src/Config.php
+++ b/src/Config.php
@@ -472,6 +472,15 @@ final class Config {
 		}
 
 		$this->settings['strings'] = $validated;
+
+		// Defense-in-depth: drop any cached read of `strings` from
+		// before validation pruned the override array. The current
+		// call order in Client::__construct is safe (validate → init
+		// reads fresh), but get_setting() is a long-lived per-key
+		// cache and a future refactor could call get_setting('strings')
+		// here. Without this unset, that future read would hit the
+		// stale pre-validation cache.
+		unset( $this->settings_cache['strings'] );
 	}
 
 	/**

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -29,6 +29,11 @@ final class Encryption {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Remote instance.
 	 *
 	 * @var Remote $remote
@@ -77,6 +82,7 @@ final class Encryption {
 	public function __construct( Config $config, Remote $remote, Logging $logging ) {
 
 		$this->config  = $config;
+		$this->strings = new Strings( $config );
 		$this->remote  = $remote;
 		$this->logging = $logging;
 
@@ -260,7 +266,7 @@ final class Encryption {
 
 			return new WP_Error(
 				'invalid_public_key_shape',
-				esc_html__( 'Support access could not be set up. The plugin\'s support team\'s encryption key has an unexpected format — please contact them and let them know.', 'trustedlogin' )
+				esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET, __( 'Support access could not be set up. The plugin\'s support team\'s encryption key has an unexpected format — please contact them and let them know.', 'trustedlogin' ) ) )
 			);
 		}
 
@@ -283,7 +289,7 @@ final class Encryption {
 
 					return new WP_Error(
 						'public_key_fingerprint_mismatch',
-						esc_html__( 'Support access could not be set up. The plugin\'s support team\'s encryption key didn\'t match the configured fingerprint — please contact them.', 'trustedlogin' )
+						esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_799354, __( 'Support access could not be set up. The plugin\'s support team\'s encryption key didn\'t match the configured fingerprint — please contact them.', 'trustedlogin' ) ) )
 					);
 				}
 			}

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -29,11 +29,6 @@ final class Encryption {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Remote instance.
 	 *
 	 * @var Remote $remote
@@ -82,7 +77,6 @@ final class Encryption {
 	public function __construct( Config $config, Remote $remote, Logging $logging ) {
 
 		$this->config  = $config;
-		$this->strings = new Strings( $config );
 		$this->remote  = $remote;
 		$this->logging = $logging;
 
@@ -266,7 +260,7 @@ final class Encryption {
 
 			return new WP_Error(
 				'invalid_public_key_shape',
-				esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET, __( 'Support access could not be set up. The plugin\'s support team\'s encryption key has an unexpected format — please contact them and let them know.', 'trustedlogin' ) ) )
+				esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET, __( 'Support access could not be set up. The plugin\'s support team\'s encryption key has an unexpected format — please contact them and let them know.', 'trustedlogin' ) ) )
 			);
 		}
 
@@ -289,7 +283,7 @@ final class Encryption {
 
 					return new WP_Error(
 						'public_key_fingerprint_mismatch',
-						esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_799354, __( 'Support access could not be set up. The plugin\'s support team\'s encryption key didn\'t match the configured fingerprint — please contact them.', 'trustedlogin' ) ) )
+						esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_799354, __( 'Support access could not be set up. The plugin\'s support team\'s encryption key didn\'t match the configured fingerprint — please contact them.', 'trustedlogin' ) ) )
 					);
 				}
 			}

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -73,6 +73,11 @@ class Endpoint {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Reports a failed support-login attempt to the SaaS.
 	 *
 	 * @var LoginAttempts
@@ -118,6 +123,7 @@ class Endpoint {
 	public function __construct( Config $config, Logging $logging, LoginAttempts $login_attempts = null, SupportUser $support_user = null ) {
 
 		$this->config         = $config;
+		$this->strings = new Strings( $config );
 		$this->logging        = $logging;
 		$this->login_attempts = $login_attempts;
 		$this->support_user   = $support_user;
@@ -396,8 +402,8 @@ class Endpoint {
 	 * with their own error chrome.
 	 */
 	private function render_standalone_failure_page() {
-		$heading = __( 'Support login could not complete', 'trustedlogin' );
-		$body    = __( 'Return to your support tool to try again.', 'trustedlogin' );
+		$heading = $this->strings->get( Strings::SUPPORT_LOGIN_COULD_NOT_COMPLETE, __( 'Support login could not complete', 'trustedlogin' ) );
+		$body    = $this->strings->get( Strings::RETURN_TO_YOUR_SUPPORT_TOOL_TO, __( 'Return to your support tool to try again.', 'trustedlogin' ) );
 
 		wp_die(
 			'<p>' . esc_html( $body ) . '</p>',

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -73,11 +73,6 @@ class Endpoint {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Reports a failed support-login attempt to the SaaS.
 	 *
 	 * @var LoginAttempts
@@ -123,7 +118,6 @@ class Endpoint {
 	public function __construct( Config $config, Logging $logging, LoginAttempts $login_attempts = null, SupportUser $support_user = null ) {
 
 		$this->config         = $config;
-		$this->strings = new Strings( $config );
 		$this->logging        = $logging;
 		$this->login_attempts = $login_attempts;
 		$this->support_user   = $support_user;
@@ -402,8 +396,8 @@ class Endpoint {
 	 * with their own error chrome.
 	 */
 	private function render_standalone_failure_page() {
-		$heading = $this->strings->get( Strings::SUPPORT_LOGIN_COULD_NOT_COMPLETE, __( 'Support login could not complete', 'trustedlogin' ) );
-		$body    = $this->strings->get( Strings::RETURN_TO_YOUR_SUPPORT_TOOL_TO, __( 'Return to your support tool to try again.', 'trustedlogin' ) );
+		$heading = Strings::get( Strings::SUPPORT_LOGIN_COULD_NOT_COMPLETE, __( 'Support login could not complete', 'trustedlogin' ) );
+		$body    = Strings::get( Strings::RETURN_TO_YOUR_SUPPORT_TOOL_TO, __( 'Return to your support tool to try again.', 'trustedlogin' ) );
 
 		wp_die(
 			'<p>' . esc_html( $body ) . '</p>',

--- a/src/Form.php
+++ b/src/Form.php
@@ -377,8 +377,8 @@ final class Form {
 		// one, so we always have a surface.
 		$support_href = '' !== $support_url ? esc_url( $support_url ) : 'mailto:' . rawurlencode( $vendor_email );
 		$support_text = '' !== $support_url
-			? sprintf( /* translators: %s: the plugin's name */ esc_html( Strings::get( Strings::CONTACT_S_SUPPORT, __( 'Contact %s support', 'trustedlogin' ) ) ), esc_html( $vendor_title ) )
-			: sprintf( /* translators: %s: the support email address */ esc_html( Strings::get( Strings::EMAIL_S, __( 'Email %s', 'trustedlogin' ) ) ), esc_html( $vendor_email ) );
+			? sprintf( esc_html( Strings::get( Strings::CONTACT_S_SUPPORT, /* translators: %s: the plugin's name */ __( 'Contact %s support', 'trustedlogin' ) ) ), esc_html( $vendor_title ) )
+			: sprintf( esc_html( Strings::get( Strings::EMAIL_S, /* translators: %s: the support email address */ __( 'Email %s', 'trustedlogin' ) ) ), esc_html( $vendor_email ) );
 
 		$retry_url = add_query_arg(
 			array(
@@ -842,11 +842,16 @@ final class Form {
 	 */
 	private function get_debug_data_consent_html() {
 
-		// translators: [link] and [/link] are replaced with a link to the Site Health page. Do not translate.
 		$output = sprintf(
 			'<h2><label><input type="checkbox" id="tl-{{ns}}-debug-data-consent" class="tl-{{ns}}-auth__checkbox--large" /> %s</label></h2>',
 			strtr(
-				esc_html( Strings::get( Strings::INCLUDE_THE_LINK_SITE_HEALTH_LINK, __( 'Include the [link]Site Health[/link] troubleshooting report', 'trustedlogin' ) ) ),
+				esc_html(
+					Strings::get(
+						Strings::INCLUDE_THE_LINK_SITE_HEALTH_LINK,
+						/* translators: [link] and [/link] are replaced with a link to the Site Health page. Do not translate. */
+						__( 'Include the [link]Site Health[/link] troubleshooting report', 'trustedlogin' )
+					)
+				),
 				array(
 					'[link]'  => '<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
 					'[/link]' => '</a>',
@@ -967,8 +972,14 @@ final class Form {
 			$logo_output = sprintf(
 				'<a href="%1$s" title="%2$s" target="_blank" rel="noreferrer noopener"><img src="%3$s" alt="%4$s" /></a>',
 				esc_url( $this->config->get_setting( 'vendor/website' ) ),
-				// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-				sprintf( 'Visit the %s website (opens in a new tab)', $this->config->get_setting( 'vendor/title' ) ),
+				esc_attr( sprintf(
+					Strings::get(
+						Strings::VISIT_VENDOR_WEBSITE,
+						/* translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets"). */
+						__( 'Visit the %s website (opens in a new tab)', 'trustedlogin' )
+					),
+					$this->config->get_setting( 'vendor/title' )
+				) ),
 				esc_attr( $this->config->get_setting( 'vendor/logo_url' ) ),
 				esc_attr( $this->config->get_setting( 'vendor/title' ) )
 			);
@@ -1430,8 +1441,17 @@ final class Form {
 		$defaults = array(
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
 			'text'        => sprintf( esc_html( Strings::get( Strings::GRANT_S_ACCESS, __( 'Grant %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name() ),
-			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			'exists_text' => sprintf( esc_html( Strings::get( Strings::EXTEND_S_ACCESS, __( 'Extend %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name(), ucwords( human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ) ),
+			'exists_text' => sprintf(
+				esc_html(
+					Strings::get(
+						Strings::EXTEND_VENDOR_ACCESS_FOR_DURATION,
+						/* translators: %1$s is replaced with the name of the software developer (e.g. "Acme Widgets"); %2$s is the human-readable duration of granted access (e.g. "1 week"). */
+						__( 'Extend %1$s Access for %2$s', 'trustedlogin' )
+					)
+				),
+				$this->config->get_display_name(),
+				ucwords( human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) )
+			),
 			'size'        => 'hero',
 			'class'       => 'button-primary',
 			'tag'         => 'a', // Inline tags only.

--- a/src/Form.php
+++ b/src/Form.php
@@ -815,7 +815,7 @@ final class Form {
 		} else {
 
 			// translators: %s is replaced with the name of the role (e.g. "Administrator").
-			$roles_summary = sprintf( esc_html( Strings::get( Strings::CREATE_A_USER_WITH_A_ROLE_60602c, __( 'Create a user with a role of %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
+			$roles_summary = sprintf( esc_html( Strings::get( Strings::CREATE_A_USER_WITH_A_ROLE_60602C, __( 'Create a user with a role of %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
 		}
 
 		$content = array(
@@ -972,14 +972,16 @@ final class Form {
 			$logo_output = sprintf(
 				'<a href="%1$s" title="%2$s" target="_blank" rel="noreferrer noopener"><img src="%3$s" alt="%4$s" /></a>',
 				esc_url( $this->config->get_setting( 'vendor/website' ) ),
-				esc_attr( sprintf(
-					Strings::get(
-						Strings::VISIT_VENDOR_WEBSITE,
-						/* translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets"). */
-						__( 'Visit the %s website (opens in a new tab)', 'trustedlogin' )
-					),
-					$this->config->get_setting( 'vendor/title' )
-				) ),
+				esc_attr(
+					sprintf(
+						Strings::get(
+							Strings::VISIT_VENDOR_WEBSITE,
+							/* translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets"). */
+							__( 'Visit the %s website (opens in a new tab)', 'trustedlogin' )
+						),
+						$this->config->get_setting( 'vendor/title' )
+					)
+				),
 				esc_attr( $this->config->get_setting( 'vendor/logo_url' ) ),
 				esc_attr( $this->config->get_setting( 'vendor/title' ) )
 			);
@@ -1100,7 +1102,7 @@ final class Form {
 			esc_html( Strings::get( Strings::LOG_URL, __( 'Log URL', 'trustedlogin' ) ) )     => '' === $log_url
 				? esc_html( Strings::get( Strings::LOG_PATH_IS_OUTSIDE_ABSPATH_NOT, __( '(Log path is outside ABSPATH; not exposing as URL.)', 'trustedlogin' ) ) )
 				: sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( $log_url ), esc_html( Strings::get( Strings::DOWNLOAD_THE_LOG, __( 'Download the log', 'trustedlogin' ) ) ) ),
-			esc_html( Strings::get( Strings::LOG_LEVEL, __( 'Log Level', 'trustedlogin' ) ) )   => esc_html( (string) $this->config->get_setting( 'logging/threshold', Strings::get( Strings::DEFAULT, __( '(Default)', 'trustedlogin' ) ) ) ),
+			esc_html( Strings::get( Strings::LOG_LEVEL, __( 'Log Level', 'trustedlogin' ) ) )   => esc_html( (string) $this->config->get_setting( 'logging/threshold', Strings::get( Strings::DEFAULT_LEVEL, __( '(Default)', 'trustedlogin' ) ) ) ),
 			esc_html( Strings::get( Strings::WEBHOOK_URL, __( 'Webhook URL', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code>', esc_html( (string) $this->config->get_setting( 'webhook/url', '(Empty)' ) ) ),
 			esc_html( Strings::get( Strings::VENDOR_PUBLIC_KEY, __( 'Vendor Public Key', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code> (<a href="%s" target="_blank">%s</a>)', esc_html( (string) $encryption->get_vendor_public_key() ), esc_url( (string) $encryption->get_remote_encryption_key_url() ), esc_html( Strings::get( Strings::VERIFY_KEY, __( 'Verify key', 'trustedlogin' ) ) ) ),
 		);
@@ -1871,7 +1873,7 @@ EOD;
 					echo esc_html(
 						sprintf(
 						// translators: %s vendor title (e.g. Acme Widgets).
-							Strings::get( Strings::YOU_ARE_LOGGED_IN_AS_A_4eed50, __( 'You are logged in as a %s support user.', 'trustedlogin' ) ),
+							Strings::get( Strings::YOU_ARE_LOGGED_IN_AS_A_4EED50, __( 'You are logged in as a %s support user.', 'trustedlogin' ) ),
 							$vendor_title
 						)
 					);

--- a/src/Form.php
+++ b/src/Form.php
@@ -41,11 +41,6 @@ final class Form {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * SiteAccess object.
 	 *
 	 * @var SiteAccess $site_access
@@ -76,7 +71,6 @@ final class Form {
 	 */
 	public function __construct( Config $config, Logging $logging, SupportUser $support_user, SiteAccess $site_access ) {
 		$this->config       = $config;
-		$this->strings = new Strings( $config );
 		$this->logging      = $logging;
 		$this->support_user = $support_user;
 		$this->site_access  = $site_access;
@@ -280,7 +274,7 @@ final class Form {
 		$_user_creator    = $_user_creator_id ? get_user_by( 'id', $_user_creator_id ) : false;
 
 		// translators: %s is the ID of the user who created the support session. The user can't be found; only the User ID is known.
-		$unknown_user_text = sprintf( esc_html( $this->strings->get( Strings::UNKNOWN_USER_D, __( 'Unknown (User #%d)', 'trustedlogin' ) ) ), $_user_creator_id );
+		$unknown_user_text = sprintf( esc_html( Strings::get( Strings::UNKNOWN_USER_D, __( 'Unknown (User #%d)', 'trustedlogin' ) ) ), $_user_creator_id );
 
 		$auth_meta = ( $_user_creator && $_user_creator->exists() ) ? esc_html( $_user_creator->display_name ) : $unknown_user_text;
 
@@ -319,9 +313,9 @@ final class Form {
 		// closing the same gap on the auth header path.
 		$content = array(
 			'display_name'         => esc_html( $support_user->display_name ),
-			'revoke_access_button' => sprintf( '<a href="%1$s" class="button button-danger alignright tl-client-revoke-button">%2$s</a>', esc_url( $revoke_url ), esc_html( $this->strings->get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ) ),
+			'revoke_access_button' => sprintf( '<a href="%1$s" class="button button-danger alignright tl-client-revoke-button">%2$s</a>', esc_url( $revoke_url ), esc_html( Strings::get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ) ),
 			// translators: %s is the display name of the user who granted access.
-			'auth_meta'            => sprintf( esc_html( $this->strings->get( Strings::CREATED_1_S_AGO_BY_2, __( 'Created %1$s ago by %2$s', 'trustedlogin' ) ) ), esc_html( human_time_diff( strtotime( $support_user->user_registered ) ) ), esc_html( $auth_meta ) ),
+			'auth_meta'            => sprintf( esc_html( Strings::get( Strings::CREATED_1_S_AGO_BY_2, __( 'Created %1$s ago by %2$s', 'trustedlogin' ) ) ), esc_html( human_time_diff( strtotime( $support_user->user_registered ) ) ), esc_html( $auth_meta ) ),
 		);
 
 		return $this->prepare_output( $template, $content );
@@ -383,8 +377,8 @@ final class Form {
 		// one, so we always have a surface.
 		$support_href = '' !== $support_url ? esc_url( $support_url ) : 'mailto:' . rawurlencode( $vendor_email );
 		$support_text = '' !== $support_url
-			? sprintf( /* translators: %s: the plugin's name */ esc_html( $this->strings->get( Strings::CONTACT_S_SUPPORT, __( 'Contact %s support', 'trustedlogin' ) ) ), esc_html( $vendor_title ) )
-			: sprintf( /* translators: %s: the support email address */ esc_html( $this->strings->get( Strings::EMAIL_S, __( 'Email %s', 'trustedlogin' ) ) ), esc_html( $vendor_email ) );
+			? sprintf( /* translators: %s: the plugin's name */ esc_html( Strings::get( Strings::CONTACT_S_SUPPORT, __( 'Contact %s support', 'trustedlogin' ) ) ), esc_html( $vendor_title ) )
+			: sprintf( /* translators: %s: the support email address */ esc_html( Strings::get( Strings::EMAIL_S, __( 'Email %s', 'trustedlogin' ) ) ), esc_html( $vendor_email ) );
 
 		$retry_url = add_query_arg(
 			array(
@@ -396,7 +390,7 @@ final class Form {
 
 		$message = $error->get_error_message();
 		if ( '' === $message ) {
-			$message = esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE, __( 'Support access is temporarily unavailable. Please try again in a few minutes.', 'trustedlogin' ) ) );
+			$message = esc_html( Strings::get( Strings::SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE, __( 'Support access is temporarily unavailable. Please try again in a few minutes.', 'trustedlogin' ) ) );
 		}
 
 		$response_html = sprintf(
@@ -419,7 +413,7 @@ final class Form {
 			'<p class="tl-%1$s-auth__retry-wrap"><a class="tl-%1$s-auth__retry" href="%2$s"><span class="dashicons dashicons-update" aria-hidden="true"></span> %3$s</a></p>',
 			esc_attr( $ns ),
 			esc_url( $retry_url ),
-			esc_html( $this->strings->get( Strings::TRY_RECONNECTING, __( 'Try reconnecting', 'trustedlogin' ) ) )
+			esc_html( Strings::get( Strings::TRY_RECONNECTING, __( 'Try reconnecting', 'trustedlogin' ) ) )
 		);
 
 		return array(
@@ -499,7 +493,7 @@ final class Form {
 			'response'                => $response_html,
 			'actions'                 => $actions_html,
 			'actions_container_class' => $grant_container,
-			'secured_by_trustedlogin' => '<span class="trustedlogin-logo-medium"></span>' . esc_html( $this->strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, __( 'Secured by TrustedLogin', 'trustedlogin' ) ) ),
+			'secured_by_trustedlogin' => '<span class="trustedlogin-logo-medium"></span>' . esc_html( Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, __( 'Secured by TrustedLogin', 'trustedlogin' ) ) ),
 			'footer'                  => $this->get_footer_html(),
 			'reference'               => $this->get_reference_html(),
 			'admin_debug'             => $this->get_admin_debug_html(),
@@ -593,7 +587,7 @@ final class Form {
 		 * @since 1.6.0
 		 * @param string $tos_anchor The text of the link to the Terms of Service.
 		 */
-		$tos_anchor = apply_filters( 'trustedlogin/' . $this->config->ns() . '/template/auth/terms_of_service/anchor', esc_html( $this->strings->get( Strings::TERMS_OF_SERVICE, __( 'Terms of Service', 'trustedlogin' ) ) ) );
+		$tos_anchor = apply_filters( 'trustedlogin/' . $this->config->ns() . '/template/auth/terms_of_service/anchor', esc_html( Strings::get( Strings::TERMS_OF_SERVICE, __( 'Terms of Service', 'trustedlogin' ) ) ) );
 
 		$tos_link_template = '<a href="{{url}}" target="_blank" rel="noopener noreferrer">{{anchor}}</a>';
 
@@ -609,7 +603,7 @@ final class Form {
 
 		$variables = array(
 			'ns'       => $this->config->ns(),
-			'tos_text' => esc_html( $this->strings->get( Strings::BY_GRANTING_ACCESS_YOU_AGREE_TO, __( 'By granting access, you agree to the {{tos_link}}.', 'trustedlogin' ) ) ),
+			'tos_text' => esc_html( Strings::get( Strings::BY_GRANTING_ACCESS_YOU_AGREE_TO, __( 'By granting access, you agree to the {{tos_link}}.', 'trustedlogin' ) ) ),
 			'tos_link' => $this->prepare_output( $tos_link_template, $tos_link_variables ),
 		);
 
@@ -650,7 +644,7 @@ final class Form {
 
 		$content = array(
 			// translators: %s is the reference ID.
-			'reference_text' => sprintf( esc_html( $this->strings->get( Strings::REFERENCE_S, __( 'Reference #%s', 'trustedlogin' ) ) ), $reference_id ),
+			'reference_text' => sprintf( esc_html( Strings::get( Strings::REFERENCE_S, __( 'Reference #%s', 'trustedlogin' ) ) ), $reference_id ),
 			'ns'             => $this->config->ns(),
 			'site_url'       => esc_html( str_replace( array( 'https://', 'http://' ), '', get_site_url() ) ),
 		);
@@ -672,7 +666,7 @@ final class Form {
 		if ( $has_access ) {
 			foreach ( $has_access as $access ) {
 				// translators: %1$s is replaced with the name of the software developer (e.g. "Acme Widgets"). %2$s is the amount of time remaining for access ("1 week").
-				$intro = sprintf( esc_html( $this->strings->get( Strings::VENDOR_HAS_SITE_ACCESS_THAT, __( '%1$s has site access that expires in %2$s.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $this->config->get_setting( 'vendor/title' ) ) . '</a>', str_replace( ' ', '&nbsp;', $this->support_user->get_expiration( $access, true, false ) ) );
+				$intro = sprintf( esc_html( Strings::get( Strings::VENDOR_HAS_SITE_ACCESS_THAT, __( '%1$s has site access that expires in %2$s.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $this->config->get_setting( 'vendor/title' ) ) . '</a>', str_replace( ' ', '&nbsp;', $this->support_user->get_expiration( $access, true, false ) ) );
 			}
 
 			return $intro;
@@ -680,10 +674,10 @@ final class Form {
 
 		if ( $this->is_login_screen() ) {
 			// translators: %1$s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			$intro = sprintf( esc_html( $this->strings->get( Strings::VENDOR_WOULD_LIKE_SUPPORT_ACCESS, __( '%1$s would like support access to this site.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
+			$intro = sprintf( esc_html( Strings::get( Strings::VENDOR_WOULD_LIKE_SUPPORT_ACCESS, __( '%1$s would like support access to this site.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
 		} else {
 			// translators: %1$s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			$intro = sprintf( esc_html( $this->strings->get( Strings::GRANT_1_S_ACCESS_TO_THIS, __( 'Grant %1$s access to this site.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
+			$intro = sprintf( esc_html( Strings::get( Strings::GRANT_1_S_ACCESS_TO_THIS, __( 'Grant %1$s access to this site.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
 		}
 
 		return $intro;
@@ -761,7 +755,7 @@ final class Form {
 					data-toggle=".tl-{{ns}}-ticket__fields">
 						%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span>
 				</span>',
-				esc_html( $this->strings->get( Strings::INCLUDE_A_MESSAGE_FOR_SUPPORT, __( 'Include a message for support?', 'trustedlogin' ) ) )
+				esc_html( Strings::get( Strings::INCLUDE_A_MESSAGE_FOR_SUPPORT, __( 'Include a message for support?', 'trustedlogin' ) ) )
 			);
 
 			$message_fields = sprintf(
@@ -776,7 +770,7 @@ final class Form {
 					></textarea>
 				</fieldset>
 			',
-				esc_html( $this->strings->get( Strings::PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE, __( 'Please describe the issue you are having.', 'trustedlogin' ) ) )
+				esc_html( Strings::get( Strings::PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE, __( 'Please describe the issue you are having.', 'trustedlogin' ) ) )
 			);
 
 			$output_template .= $this->prepare_output(
@@ -803,25 +797,25 @@ final class Form {
 		}
 
 		// translators: %s is replaced with the of time that the login will be active for (e.g. "1 week").
-		$expire_summary = sprintf( esc_html( $this->strings->get( Strings::ACCESS_THIS_SITE_FOR_S, __( 'Access this site for %s.', 'trustedlogin' ) ) ), '<strong>' . human_time_diff( 0, $this->config->get_setting( 'decay' ) ) . '</strong>' );
+		$expire_summary = sprintf( esc_html( Strings::get( Strings::ACCESS_THIS_SITE_FOR_S, __( 'Access this site for %s.', 'trustedlogin' ) ) ), '<strong>' . human_time_diff( 0, $this->config->get_setting( 'decay' ) ) . '</strong>' );
 
 		// translators: %s is replaced by the amount of time that the login will be active for (e.g. "1 week").
-		$expire_desc = '<small>' . sprintf( esc_html( $this->strings->get( Strings::ACCESS_AUTO_EXPIRES_IN_S_YOU, __( 'Access auto-expires in %s. You may revoke access at any time.', 'trustedlogin' ) ) ), human_time_diff( 0, $this->config->get_setting( 'decay' ) ) ) . '</small>';
+		$expire_desc = '<small>' . sprintf( esc_html( Strings::get( Strings::ACCESS_AUTO_EXPIRES_IN_S_YOU, __( 'Access auto-expires in %s. You may revoke access at any time.', 'trustedlogin' ) ) ), human_time_diff( 0, $this->config->get_setting( 'decay' ) ) ) . '</small>';
 
 		$cloned_role = translate_user_role( ucfirst( $this->config->get_setting( 'role' ) ) );
 
 		if ( $this->config->get_setting( 'clone_role' ) ) {
 
 			// translators: %s is replaced with the name of the role (e.g. "Administrator").
-			$roles_summary = sprintf( esc_html( $this->strings->get( Strings::CREATE_A_USER_WITH_A_ROLE, __( 'Create a user with a role based on %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
+			$roles_summary = sprintf( esc_html( Strings::get( Strings::CREATE_A_USER_WITH_A_ROLE, __( 'Create a user with a role based on %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
 
 			if ( $this->config->get_setting( 'caps/add' ) || $this->config->get_setting( 'caps/remove' ) ) {
-				$roles_summary .= sprintf( '<small class="tl-' . $ns . '-toggle" data-toggle=".tl-' . $ns . '-auth__role-container">%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span></small>', esc_html( $this->strings->get( Strings::VIEW_MODIFIED_ROLE_CAPABILITIES, __( 'View modified role capabilities', 'trustedlogin' ) ) ) );
+				$roles_summary .= sprintf( '<small class="tl-' . $ns . '-toggle" data-toggle=".tl-' . $ns . '-auth__role-container">%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span></small>', esc_html( Strings::get( Strings::VIEW_MODIFIED_ROLE_CAPABILITIES, __( 'View modified role capabilities', 'trustedlogin' ) ) ) );
 			}
 		} else {
 
 			// translators: %s is replaced with the name of the role (e.g. "Administrator").
-			$roles_summary = sprintf( esc_html( $this->strings->get( Strings::CREATE_A_USER_WITH_A_ROLE_60602c, __( 'Create a user with a role of %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
+			$roles_summary = sprintf( esc_html( Strings::get( Strings::CREATE_A_USER_WITH_A_ROLE_60602c, __( 'Create a user with a role of %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
 		}
 
 		$content = array(
@@ -852,7 +846,7 @@ final class Form {
 		$output = sprintf(
 			'<h2><label><input type="checkbox" id="tl-{{ns}}-debug-data-consent" class="tl-{{ns}}-auth__checkbox--large" /> %s</label></h2>',
 			strtr(
-				esc_html( $this->strings->get( Strings::INCLUDE_THE_LINK_SITE_HEALTH_LINK, __( 'Include the [link]Site Health[/link] troubleshooting report', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::INCLUDE_THE_LINK_SITE_HEALTH_LINK, __( 'Include the [link]Site Health[/link] troubleshooting report', 'trustedlogin' ) ) ),
 				array(
 					'[link]'  => '<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
 					'[/link]' => '</a>',
@@ -878,8 +872,8 @@ final class Form {
 		$removed = $this->config->get_setting( 'caps/remove' );
 
 		$caps  = '';
-		$caps .= $this->get_caps_section( $added, $this->strings->get( Strings::ADDITIONAL_CAPABILITIES, __( 'Additional capabilities:', 'trustedlogin' ) ), 'dashicons-yes-alt' );
-		$caps .= $this->get_caps_section( $removed, $this->strings->get( Strings::REMOVED_CAPABILITIES, __( 'Removed capabilities:', 'trustedlogin' ) ), 'dashicons-dismiss' );
+		$caps .= $this->get_caps_section( $added, Strings::get( Strings::ADDITIONAL_CAPABILITIES, __( 'Additional capabilities:', 'trustedlogin' ) ), 'dashicons-yes-alt' );
+		$caps .= $this->get_caps_section( $removed, Strings::get( Strings::REMOVED_CAPABILITIES, __( 'Removed capabilities:', 'trustedlogin' ) ), 'dashicons-dismiss' );
 
 		if ( empty( $caps ) ) {
 			return $caps;
@@ -949,10 +943,10 @@ final class Form {
 
 		$content = array(
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			'local_site'            => sprintf( esc_html( $this->strings->get( Strings::S_SUPPORT_MAY_NOT_BE_ABLE, __( '%s support may not be able to access this site.', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) ),
-			'need_access'           => esc_html( $this->strings->get( Strings::THIS_WEBSITE_IS_RUNNING_IN_A, __( 'This website is running in a local development environment. To provide support, we must be able to access your site using a publicly-accessible URL.', 'trustedlogin' ) ) ),
+			'local_site'            => sprintf( esc_html( Strings::get( Strings::S_SUPPORT_MAY_NOT_BE_ABLE, __( '%s support may not be able to access this site.', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) ),
+			'need_access'           => esc_html( Strings::get( Strings::THIS_WEBSITE_IS_RUNNING_IN_A, __( 'This website is running in a local development environment. To provide support, we must be able to access your site using a publicly-accessible URL.', 'trustedlogin' ) ) ),
 			'about_live_access_url' => esc_url( $this->config->get_setting( 'vendor/about_live_access_url', self::ABOUT_LIVE_ACCESS_URL ) ),
-			'learn_more'            => esc_html( $this->strings->get( Strings::LEARN_MORE, __( 'Learn more.', 'trustedlogin' ) ) ),
+			'learn_more'            => esc_html( Strings::get( Strings::LEARN_MORE, __( 'Learn more.', 'trustedlogin' ) ) ),
 		);
 
 		return $this->prepare_output( $notice_template, $content );
@@ -1005,7 +999,7 @@ final class Form {
 		}
 
 		$footer_links = array(
-			esc_html( $this->strings->get( Strings::LEARN_ABOUT_TRUSTEDLOGIN, __( 'Learn about TrustedLogin', 'trustedlogin' ) ) )                    => self::ABOUT_TL_URL,
+			esc_html( Strings::get( Strings::LEARN_ABOUT_TRUSTEDLOGIN, __( 'Learn about TrustedLogin', 'trustedlogin' ) ) )                    => self::ABOUT_TL_URL,
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
 			sprintf( 'Visit %s support', $this->config->get_setting( 'vendor/title' ) ) => $support_url,
 		);
@@ -1089,15 +1083,15 @@ final class Form {
 		};
 
 		$items = array(
-			esc_html( $this->strings->get( Strings::TRUSTEDLOGIN_STATUS, __( 'TrustedLogin Status', 'trustedlogin' ) ) ) => sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( 'https://status.trustedlogin.com' ), is_wp_error( wp_remote_request( 'https://app.trustedlogin.com/api/status' ) ) ? esc_html( $this->strings->get( Strings::OFFLINE, __( 'Offline', 'trustedlogin' ) ) ) : esc_html( $this->strings->get( Strings::ONLINE, __( 'Online', 'trustedlogin' ) ) ) ),
-			esc_html( $this->strings->get( Strings::API_KEY, __( 'API Key', 'trustedlogin' ) ) )     => sprintf( '<code>%s</code>', esc_html( $mask( $api_key ) ) ),
-			esc_html( $this->strings->get( Strings::LICENSE_KEY, __( 'License Key', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code>', esc_html( $mask( $license_key ) ) ),
-			esc_html( $this->strings->get( Strings::LOG_URL, __( 'Log URL', 'trustedlogin' ) ) )     => '' === $log_url
-				? esc_html( $this->strings->get( Strings::LOG_PATH_IS_OUTSIDE_ABSPATH_NOT, __( '(Log path is outside ABSPATH; not exposing as URL.)', 'trustedlogin' ) ) )
-				: sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( $log_url ), esc_html( $this->strings->get( Strings::DOWNLOAD_THE_LOG, __( 'Download the log', 'trustedlogin' ) ) ) ),
-			esc_html( $this->strings->get( Strings::LOG_LEVEL, __( 'Log Level', 'trustedlogin' ) ) )   => esc_html( (string) $this->config->get_setting( 'logging/threshold', $this->strings->get( Strings::DEFAULT, __( '(Default)', 'trustedlogin' ) ) ) ),
-			esc_html( $this->strings->get( Strings::WEBHOOK_URL, __( 'Webhook URL', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code>', esc_html( (string) $this->config->get_setting( 'webhook/url', '(Empty)' ) ) ),
-			esc_html( $this->strings->get( Strings::VENDOR_PUBLIC_KEY, __( 'Vendor Public Key', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code> (<a href="%s" target="_blank">%s</a>)', esc_html( (string) $encryption->get_vendor_public_key() ), esc_url( (string) $encryption->get_remote_encryption_key_url() ), esc_html( $this->strings->get( Strings::VERIFY_KEY, __( 'Verify key', 'trustedlogin' ) ) ) ),
+			esc_html( Strings::get( Strings::TRUSTEDLOGIN_STATUS, __( 'TrustedLogin Status', 'trustedlogin' ) ) ) => sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( 'https://status.trustedlogin.com' ), is_wp_error( wp_remote_request( 'https://app.trustedlogin.com/api/status' ) ) ? esc_html( Strings::get( Strings::OFFLINE, __( 'Offline', 'trustedlogin' ) ) ) : esc_html( Strings::get( Strings::ONLINE, __( 'Online', 'trustedlogin' ) ) ) ),
+			esc_html( Strings::get( Strings::API_KEY, __( 'API Key', 'trustedlogin' ) ) )     => sprintf( '<code>%s</code>', esc_html( $mask( $api_key ) ) ),
+			esc_html( Strings::get( Strings::LICENSE_KEY, __( 'License Key', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code>', esc_html( $mask( $license_key ) ) ),
+			esc_html( Strings::get( Strings::LOG_URL, __( 'Log URL', 'trustedlogin' ) ) )     => '' === $log_url
+				? esc_html( Strings::get( Strings::LOG_PATH_IS_OUTSIDE_ABSPATH_NOT, __( '(Log path is outside ABSPATH; not exposing as URL.)', 'trustedlogin' ) ) )
+				: sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( $log_url ), esc_html( Strings::get( Strings::DOWNLOAD_THE_LOG, __( 'Download the log', 'trustedlogin' ) ) ) ),
+			esc_html( Strings::get( Strings::LOG_LEVEL, __( 'Log Level', 'trustedlogin' ) ) )   => esc_html( (string) $this->config->get_setting( 'logging/threshold', Strings::get( Strings::DEFAULT, __( '(Default)', 'trustedlogin' ) ) ) ),
+			esc_html( Strings::get( Strings::WEBHOOK_URL, __( 'Webhook URL', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code>', esc_html( (string) $this->config->get_setting( 'webhook/url', '(Empty)' ) ) ),
+			esc_html( Strings::get( Strings::VENDOR_PUBLIC_KEY, __( 'Vendor Public Key', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code> (<a href="%s" target="_blank">%s</a>)', esc_html( (string) $encryption->get_vendor_public_key() ), esc_url( (string) $encryption->get_remote_encryption_key_url() ), esc_html( Strings::get( Strings::VERIFY_KEY, __( 'Verify key', 'trustedlogin' ) ) ) ),
 		);
 
 		$debugging_info = '';
@@ -1136,9 +1130,9 @@ final class Form {
 			$debugging_output,
 			array(
 				'ns'              => $this->config->ns(),
-				'debugging_label' => esc_html( $this->strings->get( Strings::DEBUGGING_INFO, __( 'Debugging Info', 'trustedlogin' ) ) ),
+				'debugging_label' => esc_html( Strings::get( Strings::DEBUGGING_INFO, __( 'Debugging Info', 'trustedlogin' ) ) ),
 				'debugging_info'  => $debugging_info,
-				'tl_config_label' => esc_html( $this->strings->get( Strings::TRUSTEDLOGIN_CONFIG, __( 'TrustedLogin Config', 'trustedlogin' ) ) ),
+				'tl_config_label' => esc_html( Strings::get( Strings::TRUSTEDLOGIN_CONFIG, __( 'TrustedLogin Config', 'trustedlogin' ) ) ),
 				'tl_config'       => '<pre>' . esc_html( print_r( $config_dump, true ) ) . '</pre>', // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			)
 		);
@@ -1435,9 +1429,9 @@ final class Form {
 
 		$defaults = array(
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			'text'        => sprintf( esc_html( $this->strings->get( Strings::GRANT_S_ACCESS, __( 'Grant %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name() ),
+			'text'        => sprintf( esc_html( Strings::get( Strings::GRANT_S_ACCESS, __( 'Grant %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name() ),
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			'exists_text' => sprintf( esc_html( $this->strings->get( Strings::EXTEND_S_ACCESS, __( 'Extend %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name(), ucwords( human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ) ),
+			'exists_text' => sprintf( esc_html( Strings::get( Strings::EXTEND_S_ACCESS, __( 'Extend %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name(), ucwords( human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ) ),
 			'size'        => 'hero',
 			'class'       => 'button-primary',
 			'tag'         => 'a', // Inline tags only.
@@ -1501,7 +1495,7 @@ final class Form {
 		if ( $atts['powered_by'] ) {
 			$powered_by = sprintf(
 				'<small><span class="trustedlogin-logo"></span>%s</small>',
-				esc_html( $this->strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, __( 'Secured by TrustedLogin', 'trustedlogin' ) ) )
+				esc_html( Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, __( 'Secured by TrustedLogin', 'trustedlogin' ) ) )
 			);
 		}
 
@@ -1576,7 +1570,7 @@ final class Form {
 		$query_args = apply_filters(
 			'trustedlogin/' . $this->config->ns() . '/support_url/query_args',
 			array(
-				'message' => $this->strings->get( Strings::COULD_NOT_CREATE_SUPPORT_ACCESS, __( 'Could not create support access.', 'trustedlogin' ) ),
+				'message' => Strings::get( Strings::COULD_NOT_CREATE_SUPPORT_ACCESS, __( 'Could not create support access.', 'trustedlogin' ) ),
 				'ref'     => Client::get_reference_id(),
 			)
 		);
@@ -1585,12 +1579,12 @@ final class Form {
 			'<p>%s</p><p>%s</p>',
 			sprintf(
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-				esc_html( $this->strings->get( Strings::THE_USER_DETAILS_COULD_NOT_BE, __( 'The user details could not be sent to %1$s automatically.', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::THE_USER_DETAILS_COULD_NOT_BE, __( 'The user details could not be sent to %1$s automatically.', 'trustedlogin' ) ) ),
 				$vendor_title
 			),
 			sprintf(
 			// translators: %1$s is the vendor support url and %2$s is the vendor title.
-				$this->strings->get( Strings::PLEASE_A_HREF_1_S_TARGET, __( 'Please <a href="%1$s" target="_blank">click here</a> to go to the %2$s support site', 'trustedlogin' ) ),
+				Strings::get( Strings::PLEASE_A_HREF_1_S_TARGET, __( 'Please <a href="%1$s" target="_blank">click here</a> to go to the %2$s support site', 'trustedlogin' ) ),
 				esc_url( add_query_arg( $query_args, $this->config->get_setting( 'vendor/support_url' ) ) ),
 				$vendor_title
 			)
@@ -1598,45 +1592,45 @@ final class Form {
 
 		$translations = array(
 			'buttons' => array(
-				'confirm'    => esc_html( $this->strings->get( Strings::CONFIRM, __( 'Confirm', 'trustedlogin' ) ) ),
-				'ok'         => esc_html( $this->strings->get( Strings::OK, __( 'Ok', 'trustedlogin' ) ) ),
+				'confirm'    => esc_html( Strings::get( Strings::CONFIRM, __( 'Confirm', 'trustedlogin' ) ) ),
+				'ok'         => esc_html( Strings::get( Strings::OK, __( 'Ok', 'trustedlogin' ) ) ),
 				// translators: %1$s is the vendor title.
-				'go_to_site' => sprintf( $this->strings->get( Strings::GO_TO_1_S_SUPPORT_SITE, __( 'Go to %1$s support site', 'trustedlogin' ) ), $vendor_title ),
-				'close'      => esc_html( $this->strings->get( Strings::CLOSE, __( 'Close', 'trustedlogin' ) ) ),
-				'cancel'     => esc_html( $this->strings->get( Strings::CANCEL, __( 'Cancel', 'trustedlogin' ) ) ),
+				'go_to_site' => sprintf( Strings::get( Strings::GO_TO_1_S_SUPPORT_SITE, __( 'Go to %1$s support site', 'trustedlogin' ) ), $vendor_title ),
+				'close'      => esc_html( Strings::get( Strings::CLOSE, __( 'Close', 'trustedlogin' ) ) ),
+				'cancel'     => esc_html( Strings::get( Strings::CANCEL, __( 'Cancel', 'trustedlogin' ) ) ),
 				// translators: %1$s is the vendor title.
-				'revoke'     => sprintf( esc_html( $this->strings->get( Strings::REVOKE_1_S_SUPPORT_ACCESS, __( 'Revoke %1$s support access', 'trustedlogin' ) ) ), $vendor_title ),
-				'copy'       => esc_html( $this->strings->get( Strings::COPY, __( 'Copy', 'trustedlogin' ) ) ),
-				'copied'     => esc_html( $this->strings->get( Strings::COPIED, __( 'Copied!', 'trustedlogin' ) ) ),
+				'revoke'     => sprintf( esc_html( Strings::get( Strings::REVOKE_1_S_SUPPORT_ACCESS, __( 'Revoke %1$s support access', 'trustedlogin' ) ) ), $vendor_title ),
+				'copy'       => esc_html( Strings::get( Strings::COPY, __( 'Copy', 'trustedlogin' ) ) ),
+				'copied'     => esc_html( Strings::get( Strings::COPIED, __( 'Copied!', 'trustedlogin' ) ) ),
 			),
 			'a11y'    => array(
-				'opens_new_window' => esc_attr( $this->strings->get( Strings::THIS_LINK_OPENS_IN_A_NEW, __( '(This link opens in a new window.)', 'trustedlogin' ) ) ),
-				'copied_text'      => esc_html( $this->strings->get( Strings::THE_ACCESS_KEY_HAS_BEEN_COPIED, __( 'The access key has been copied to your clipboard.', 'trustedlogin' ) ) ),
+				'opens_new_window' => esc_attr( Strings::get( Strings::THIS_LINK_OPENS_IN_A_NEW, __( '(This link opens in a new window.)', 'trustedlogin' ) ) ),
+				'copied_text'      => esc_html( Strings::get( Strings::THE_ACCESS_KEY_HAS_BEEN_COPIED, __( 'The access key has been copied to your clipboard.', 'trustedlogin' ) ) ),
 			),
 			'status'  => array(
 				'synced'             => array(
-					'title'   => esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_GRANTED, __( 'Support access granted', 'trustedlogin' ) ) ),
+					'title'   => esc_html( Strings::get( Strings::SUPPORT_ACCESS_GRANTED, __( 'Support access granted', 'trustedlogin' ) ) ),
 					'content' => sprintf(
 					// translators: %1$s is the vendor title.
-						$this->strings->get( Strings::A_TEMPORARY_SUPPORT_USER_HAS_BEEN, __( 'A temporary support user has been created, and sent to %1$s support.', 'trustedlogin' ) ),
+						Strings::get( Strings::A_TEMPORARY_SUPPORT_USER_HAS_BEEN, __( 'A temporary support user has been created, and sent to %1$s support.', 'trustedlogin' ) ),
 						$vendor_title
 					),
 				),
 				'pending'            => array(
 					// translators: %1$s is the vendor title.
-					'content' => sprintf( $this->strings->get( Strings::GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR, __( 'Generating & encrypting secure support access for %1$s', 'trustedlogin' ) ), $vendor_title ),
+					'content' => sprintf( Strings::get( Strings::GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR, __( 'Generating & encrypting secure support access for %1$s', 'trustedlogin' ) ), $vendor_title ),
 				),
 				'extending'          => array(
 					// translators: %1$s is the vendor title and %2$s is the human-readable expiration time (for example, "1 week").
-					'content' => sprintf( $this->strings->get( Strings::EXTENDING_SUPPORT_ACCESS_FOR_1_S, __( 'Extending support access for %1$s by %2$s', 'trustedlogin' ) ), $vendor_title, human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ),
+					'content' => sprintf( Strings::get( Strings::EXTENDING_SUPPORT_ACCESS_FOR_1_S, __( 'Extending support access for %1$s by %2$s', 'trustedlogin' ) ), $vendor_title, human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ),
 				),
 				'syncing'            => array(
 					// translators: %1$s is the vendor title.
-					'content' => sprintf( $this->strings->get( Strings::SENDING_ENCRYPTED_ACCESS_TO_1_S, __( 'Sending encrypted access to %1$s.', 'trustedlogin' ) ), $vendor_title ),
+					'content' => sprintf( Strings::get( Strings::SENDING_ENCRYPTED_ACCESS_TO_1_S, __( 'Sending encrypted access to %1$s.', 'trustedlogin' ) ), $vendor_title ),
 				),
 				'error'              => array(
 					// translators: %1$s is the vendor title.
-					'title'   => sprintf( $this->strings->get( Strings::COULDN_T_REGISTER_SUPPORT_ACCESS_WITH, __( 'Couldn\'t register support access with %1$s', 'trustedlogin' ) ), $vendor_title ),
+					'title'   => sprintf( Strings::get( Strings::COULDN_T_REGISTER_SUPPORT_ACCESS_WITH, __( 'Couldn\'t register support access with %1$s', 'trustedlogin' ) ), $vendor_title ),
 					'content' => wp_kses(
 						$error_content,
 						array(
@@ -1650,46 +1644,46 @@ final class Form {
 					),
 				),
 				'cancel'             => array(
-					'title'   => esc_html( $this->strings->get( Strings::ACTION_CANCELLED, __( 'Action Cancelled', 'trustedlogin' ) ) ),
+					'title'   => esc_html( Strings::get( Strings::ACTION_CANCELLED, __( 'Action Cancelled', 'trustedlogin' ) ) ),
 					'content' => sprintf(
 					// translators: %1$s is the vendor title.
-						$this->strings->get( Strings::A_SUPPORT_ACCOUNT_FOR_1_S, __( 'A support account for %1$s was not created.', 'trustedlogin' ) ),
+						Strings::get( Strings::A_SUPPORT_ACCOUNT_FOR_1_S, __( 'A support account for %1$s was not created.', 'trustedlogin' ) ),
 						$vendor_title
 					),
 				),
 				'failed'             => array(
-					'title'   => esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_WAS_NOT_GRANTED, __( 'Support Access Was Not Granted', 'trustedlogin' ) ) ),
-					'content' => esc_html( $this->strings->get( Strings::THERE_WAS_AN_ERROR_GRANTING_ACCESS, __( 'There was an error granting access: ', 'trustedlogin' ) ) ),
+					'title'   => esc_html( Strings::get( Strings::SUPPORT_ACCESS_WAS_NOT_GRANTED, __( 'Support Access Was Not Granted', 'trustedlogin' ) ) ),
+					'content' => esc_html( Strings::get( Strings::THERE_WAS_AN_ERROR_GRANTING_ACCESS, __( 'There was an error granting access: ', 'trustedlogin' ) ) ),
 				),
 				'failed_permissions' => array(
-					'content' => esc_html( $this->strings->get( Strings::YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE, __( 'Your authorized session has expired. Please refresh the page.', 'trustedlogin' ) ) ),
+					'content' => esc_html( Strings::get( Strings::YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE, __( 'Your authorized session has expired. Please refresh the page.', 'trustedlogin' ) ) ),
 				),
 				'timeout'            => array(
-					'content' => esc_html( $this->strings->get( Strings::THE_REQUEST_TOOK_TOO_LONG_TO, __( 'The request took too long to complete. Please try again.', 'trustedlogin' ) ) ),
+					'content' => esc_html( Strings::get( Strings::THE_REQUEST_TOOK_TOO_LONG_TO, __( 'The request took too long to complete. Please try again.', 'trustedlogin' ) ) ),
 				),
 				'accesskey'          => array(
-					'title'       => esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_KEY_CREATED, __( 'Support Access Key Created', 'trustedlogin' ) ) ),
+					'title'       => esc_html( Strings::get( Strings::SUPPORT_ACCESS_KEY_CREATED, __( 'Support Access Key Created', 'trustedlogin' ) ) ),
 					'content'     => sprintf(
 					// translators: %1$s is the vendor title.
-						$this->strings->get( Strings::SHARE_THIS_ACCESS_KEY_WITH_1, __( 'Share this access key with %1$s to give them secure access:', 'trustedlogin' ) ),
+						Strings::get( Strings::SHARE_THIS_ACCESS_KEY_WITH_1, __( 'Share this access key with %1$s to give them secure access:', 'trustedlogin' ) ),
 						$vendor_title
 					),
 					'revoke_link' => esc_url( add_query_arg( array( Endpoint::REVOKE_SUPPORT_QUERY_PARAM => $this->config->ns() ), admin_url() ) ),
 				),
 				'error404'           => array(
-					'title'   => esc_html( $this->strings->get( Strings::THE_SUPPORT_TEAM_S_SITE_COULD, __( 'The support team\'s site could not be found.', 'trustedlogin' ) ) ),
+					'title'   => esc_html( Strings::get( Strings::THE_SUPPORT_TEAM_S_SITE_COULD, __( 'The support team\'s site could not be found.', 'trustedlogin' ) ) ),
 					'content' => '',
 				),
 				'error409'           => array(
 					'title'   => sprintf(
 					// translators: %1$s is the vendor title.
-						$this->strings->get( Strings::VENDOR_SUPPORT_USER_ALREADY_EXISTS, __( '%1$s Support user already exists', 'trustedlogin' ) ),
+						Strings::get( Strings::VENDOR_SUPPORT_USER_ALREADY_EXISTS, __( '%1$s Support user already exists', 'trustedlogin' ) ),
 						$vendor_title
 					),
 					'content' => sprintf(
 						wp_kses(
 						// translators: %1$s is the vendor title, %2$s is the URL to the users list page.
-							$this->strings->get( Strings::A_SUPPORT_USER_FOR_1_S, __( 'A support user for %1$s already exists. You may revoke this support access from your <a href="%2$s" target="_blank">Users list</a>.', 'trustedlogin' ) ),
+							Strings::get( Strings::A_SUPPORT_USER_FOR_1_S, __( 'A support user for %1$s already exists. You may revoke this support access from your <a href="%2$s" target="_blank">Users list</a>.', 'trustedlogin' ) ),
 							array(
 								'a' => array(
 									'href'   => array(),
@@ -1732,7 +1726,7 @@ final class Form {
 		if ( empty( $support_users ) ) {
 
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			$return = '<h3>' . sprintf( esc_html( $this->strings->get( Strings::NO_S_USERS_EXIST, __( 'No %s users exist.', 'trustedlogin' ) ) ), esc_html( $this->config->get_setting( 'vendor/title' ) ) ) . '</h3>';
+			$return = '<h3>' . sprintf( esc_html( Strings::get( Strings::NO_S_USERS_EXIST, __( 'No %s users exist.', 'trustedlogin' ) ) ), esc_html( $this->config->get_setting( 'vendor/title' ) ) ) . '</h3>';
 
 			if ( $print_and_return ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -1758,11 +1752,11 @@ EOD;
 				/* %1$s */
 				sanitize_title( $this->config->ns() ),
 				/* %2$s */
-				esc_html( $this->strings->get( Strings::ERROR, __( 'Error', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::ERROR, __( 'Error', 'trustedlogin' ) ) ),
 				/* %3$s */
 				'div',
 				/* %4$s */
-				esc_html( $this->strings->get( Strings::THERE_WAS_AN_ERROR_RETURNING_THE, __( 'There was an error returning the access key.', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::THERE_WAS_AN_ERROR_RETURNING_THE, __( 'There was an error returning the access key.', 'trustedlogin' ) ) ),
 				/* %5$s */
 				esc_html( $access_key->get_error_message() )
 			);
@@ -1784,20 +1778,20 @@ EOD;
 				/* %1$s */
 				sanitize_title( $this->config->ns() ),
 				/* %2$s */
-				esc_html( $this->strings->get( Strings::SITE_ACCESS_KEY, __( 'Site access key:', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::SITE_ACCESS_KEY, __( 'Site access key:', 'trustedlogin' ) ) ),
 				/* %3$s */
-				esc_html( $this->strings->get( Strings::ACCESS_KEY, __( 'Access Key', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::ACCESS_KEY, __( 'Access Key', 'trustedlogin' ) ) ),
 				/* %4$s */
 				esc_attr( $access_key ),
 				/* %5$s */
-				esc_html( $this->strings->get( Strings::COPY, __( 'Copy', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::COPY, __( 'Copy', 'trustedlogin' ) ) ),
 				/* %6$s */
 				'div',
 				/* %7$s */
-				esc_html( $this->strings->get( Strings::COPY_THE_ACCESS_KEY_TO_YOUR, __( 'Copy the access key to your clipboard', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::COPY_THE_ACCESS_KEY_TO_YOUR, __( 'Copy the access key to your clipboard', 'trustedlogin' ) ) ),
 				// %8$s
 				// translators: %s is the display name of the TrustedLogin support user.
-				sprintf( esc_html( $this->strings->get( Strings::THE_ACCESS_KEY_IS_NOT_A, __( 'The access key is not a password; only %1$s will be able to access your site using this code. You may share this access key on support forums.', 'trustedlogin' ) ) ), esc_html( $this->support_user->get_first()->display_name ) ),
+				sprintf( esc_html( Strings::get( Strings::THE_ACCESS_KEY_IS_NOT_A, __( 'The access key is not a password; only %1$s will be able to access your site using this code. You may share this access key on support forums.', 'trustedlogin' ) ) ), esc_html( $this->support_user->get_first()->display_name ) ),
 				/* %9$s */
 				esc_attr( $this->support_user->get_expiration( $this->support_user->get_first() ) )
 			);
@@ -1857,7 +1851,7 @@ EOD;
 					echo esc_html(
 						sprintf(
 						// translators: %s vendor title (e.g. Acme Widgets).
-							$this->strings->get( Strings::YOU_ARE_LOGGED_IN_AS_A_4eed50, __( 'You are logged in as a %s support user.', 'trustedlogin' ) ),
+							Strings::get( Strings::YOU_ARE_LOGGED_IN_AS_A_4eed50, __( 'You are logged in as a %s support user.', 'trustedlogin' ) ),
 							$vendor_title
 						)
 					);
@@ -1869,7 +1863,7 @@ EOD;
 						echo esc_html(
 							sprintf(
 							// translators: %s human-readable duration like "1 week".
-								$this->strings->get( Strings::ACCESS_EXPIRES_IN_S, __( 'Access expires in %s.', 'trustedlogin' ) ),
+								Strings::get( Strings::ACCESS_EXPIRES_IN_S, __( 'Access expires in %s.', 'trustedlogin' ) ),
 								$expiration
 							)
 						);
@@ -1891,7 +1885,7 @@ EOD;
 					<?php
 					printf(
 						/* translators: %s: the currently signed-in user's display name */
-						esc_html( $this->strings->get( Strings::YOU_WERE_ALREADY_SIGNED_IN_AS, __( 'You were already signed in as %s, so the support login was skipped. You can grant or revoke access as usual.', 'trustedlogin' ) ) ),
+						esc_html( Strings::get( Strings::YOU_WERE_ALREADY_SIGNED_IN_AS, __( 'You were already signed in as %s, so the support login was skipped. You can grant or revoke access as usual.', 'trustedlogin' ) ) ),
 						esc_html( wp_get_current_user()->display_name )
 					);
 					?>
@@ -1920,11 +1914,11 @@ EOD;
 			<h3>
 			<?php
 				// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-				echo esc_html( sprintf( $this->strings->get( Strings::S_ACCESS_REVOKED, __( '%s access revoked.', 'trustedlogin' ) ), $this->config->get_setting( 'vendor/title' ) ) );
+				echo esc_html( sprintf( Strings::get( Strings::S_ACCESS_REVOKED, __( '%s access revoked.', 'trustedlogin' ) ), $this->config->get_setting( 'vendor/title' ) ) );
 			?>
 				</h3>
 			<?php if ( ! current_user_can( 'delete_users' ) ) { ?>
-				<p><?php echo esc_html( $this->strings->get( Strings::YOU_MAY_SAFELY_CLOSE_THIS_WINDOW, __( 'You may safely close this window.', 'trustedlogin' ) ) ); ?></p>
+				<p><?php echo esc_html( Strings::get( Strings::YOU_MAY_SAFELY_CLOSE_THIS_WINDOW, __( 'You may safely close this window.', 'trustedlogin' ) ) ); ?></p>
 			<?php } ?>
 		</div>
 		<?php

--- a/src/Form.php
+++ b/src/Form.php
@@ -41,6 +41,11 @@ final class Form {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * SiteAccess object.
 	 *
 	 * @var SiteAccess $site_access
@@ -62,11 +67,6 @@ final class Form {
 	private $logging;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Form constructor.
 	 *
 	 * @param Config      $config Config object.
@@ -76,10 +76,10 @@ final class Form {
 	 */
 	public function __construct( Config $config, Logging $logging, SupportUser $support_user, SiteAccess $site_access ) {
 		$this->config       = $config;
+		$this->strings = new Strings( $config );
 		$this->logging      = $logging;
 		$this->support_user = $support_user;
 		$this->site_access  = $site_access;
-		$this->strings      = new Strings( $config );
 	}
 
 	/**
@@ -280,7 +280,7 @@ final class Form {
 		$_user_creator    = $_user_creator_id ? get_user_by( 'id', $_user_creator_id ) : false;
 
 		// translators: %s is the ID of the user who created the support session. The user can't be found; only the User ID is known.
-		$unknown_user_text = sprintf( esc_html__( 'Unknown (User #%d)', 'trustedlogin' ), $_user_creator_id );
+		$unknown_user_text = sprintf( esc_html( $this->strings->get( Strings::UNKNOWN_USER_D, __( 'Unknown (User #%d)', 'trustedlogin' ) ) ), $_user_creator_id );
 
 		$auth_meta = ( $_user_creator && $_user_creator->exists() ) ? esc_html( $_user_creator->display_name ) : $unknown_user_text;
 
@@ -319,18 +319,9 @@ final class Form {
 		// closing the same gap on the auth header path.
 		$content = array(
 			'display_name'         => esc_html( $support_user->display_name ),
-			'revoke_access_button' => sprintf(
-				'<a href="%1$s" class="button button-danger alignright tl-client-revoke-button">%2$s</a>',
-				esc_url( $revoke_url ),
-				esc_html( $this->strings->get( Strings::REVOKE_ACCESS_BUTTON, __( 'Revoke Access', 'trustedlogin' ) ) )
-			),
+			'revoke_access_button' => sprintf( '<a href="%1$s" class="button button-danger alignright tl-client-revoke-button">%2$s</a>', esc_url( $revoke_url ), esc_html( $this->strings->get( Strings::REVOKE_ACCESS, __( 'Revoke Access', 'trustedlogin' ) ) ) ),
 			// translators: %s is the display name of the user who granted access.
-			'auth_meta'            => sprintf(
-				/* translators: %1$s: human-readable time ago; %2$s: display name of the user who granted access */
-				esc_html( $this->strings->get( Strings::CREATED_TIME_AGO, __( 'Created %1$s ago by %2$s', 'trustedlogin' ) ) ),
-				esc_html( human_time_diff( strtotime( $support_user->user_registered ) ) ),
-				esc_html( $auth_meta )
-			),
+			'auth_meta'            => sprintf( esc_html( $this->strings->get( Strings::CREATED_1_S_AGO_BY_2, __( 'Created %1$s ago by %2$s', 'trustedlogin' ) ) ), esc_html( human_time_diff( strtotime( $support_user->user_registered ) ) ), esc_html( $auth_meta ) ),
 		);
 
 		return $this->prepare_output( $template, $content );
@@ -392,8 +383,8 @@ final class Form {
 		// one, so we always have a surface.
 		$support_href = '' !== $support_url ? esc_url( $support_url ) : 'mailto:' . rawurlencode( $vendor_email );
 		$support_text = '' !== $support_url
-			? sprintf( /* translators: %s: the plugin's name */ esc_html__( 'Contact %s support', 'trustedlogin' ), esc_html( $vendor_title ) )
-			: sprintf( /* translators: %s: the support email address */ esc_html__( 'Email %s', 'trustedlogin' ), esc_html( $vendor_email ) );
+			? sprintf( /* translators: %s: the plugin's name */ esc_html( $this->strings->get( Strings::CONTACT_S_SUPPORT, __( 'Contact %s support', 'trustedlogin' ) ) ), esc_html( $vendor_title ) )
+			: sprintf( /* translators: %s: the support email address */ esc_html( $this->strings->get( Strings::EMAIL_S, __( 'Email %s', 'trustedlogin' ) ) ), esc_html( $vendor_email ) );
 
 		$retry_url = add_query_arg(
 			array(
@@ -405,12 +396,7 @@ final class Form {
 
 		$message = $error->get_error_message();
 		if ( '' === $message ) {
-			$message = esc_html(
-				$this->strings->get(
-					Strings::SUPPORT_TEMPORARILY_UNAVAILABLE,
-					__( 'Support access is temporarily unavailable. Please try again in a few minutes.', 'trustedlogin' )
-				)
-			);
+			$message = esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE, __( 'Support access is temporarily unavailable. Please try again in a few minutes.', 'trustedlogin' ) ) );
 		}
 
 		$response_html = sprintf(
@@ -513,9 +499,7 @@ final class Form {
 			'response'                => $response_html,
 			'actions'                 => $actions_html,
 			'actions_container_class' => $grant_container,
-			'secured_by_trustedlogin' => '<span class="trustedlogin-logo-medium"></span>' . esc_html(
-				$this->strings->get( Strings::SECURED_BY, __( 'Secured by TrustedLogin', 'trustedlogin' ) )
-			),
+			'secured_by_trustedlogin' => '<span class="trustedlogin-logo-medium"></span>' . esc_html( $this->strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, __( 'Secured by TrustedLogin', 'trustedlogin' ) ) ),
 			'footer'                  => $this->get_footer_html(),
 			'reference'               => $this->get_reference_html(),
 			'admin_debug'             => $this->get_admin_debug_html(),
@@ -609,7 +593,7 @@ final class Form {
 		 * @since 1.6.0
 		 * @param string $tos_anchor The text of the link to the Terms of Service.
 		 */
-		$tos_anchor = apply_filters( 'trustedlogin/' . $this->config->ns() . '/template/auth/terms_of_service/anchor', esc_html__( 'Terms of Service', 'trustedlogin' ) );
+		$tos_anchor = apply_filters( 'trustedlogin/' . $this->config->ns() . '/template/auth/terms_of_service/anchor', esc_html( $this->strings->get( Strings::TERMS_OF_SERVICE, __( 'Terms of Service', 'trustedlogin' ) ) ) );
 
 		$tos_link_template = '<a href="{{url}}" target="_blank" rel="noopener noreferrer">{{anchor}}</a>';
 
@@ -625,7 +609,7 @@ final class Form {
 
 		$variables = array(
 			'ns'       => $this->config->ns(),
-			'tos_text' => esc_html__( 'By granting access, you agree to the {{tos_link}}.', 'trustedlogin' ),
+			'tos_text' => esc_html( $this->strings->get( Strings::BY_GRANTING_ACCESS_YOU_AGREE_TO, __( 'By granting access, you agree to the {{tos_link}}.', 'trustedlogin' ) ) ),
 			'tos_link' => $this->prepare_output( $tos_link_template, $tos_link_variables ),
 		);
 
@@ -666,7 +650,7 @@ final class Form {
 
 		$content = array(
 			// translators: %s is the reference ID.
-			'reference_text' => sprintf( esc_html__( 'Reference #%s', 'trustedlogin' ), $reference_id ),
+			'reference_text' => sprintf( esc_html( $this->strings->get( Strings::REFERENCE_S, __( 'Reference #%s', 'trustedlogin' ) ) ), $reference_id ),
 			'ns'             => $this->config->ns(),
 			'site_url'       => esc_html( str_replace( array( 'https://', 'http://' ), '', get_site_url() ) ),
 		);
@@ -688,7 +672,7 @@ final class Form {
 		if ( $has_access ) {
 			foreach ( $has_access as $access ) {
 				// translators: %1$s is replaced with the name of the software developer (e.g. "Acme Widgets"). %2$s is the amount of time remaining for access ("1 week").
-				$intro = sprintf( esc_html__( '%1$s has site access that expires in %2$s.', 'trustedlogin' ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $this->config->get_setting( 'vendor/title' ) ) . '</a>', str_replace( ' ', '&nbsp;', $this->support_user->get_expiration( $access, true, false ) ) );
+				$intro = sprintf( esc_html( $this->strings->get( Strings::VENDOR_HAS_SITE_ACCESS_THAT, __( '%1$s has site access that expires in %2$s.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $this->config->get_setting( 'vendor/title' ) ) . '</a>', str_replace( ' ', '&nbsp;', $this->support_user->get_expiration( $access, true, false ) ) );
 			}
 
 			return $intro;
@@ -696,10 +680,10 @@ final class Form {
 
 		if ( $this->is_login_screen() ) {
 			// translators: %1$s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			$intro = sprintf( esc_html__( '%1$s would like support access to this site.', 'trustedlogin' ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
+			$intro = sprintf( esc_html( $this->strings->get( Strings::VENDOR_WOULD_LIKE_SUPPORT_ACCESS, __( '%1$s would like support access to this site.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
 		} else {
 			// translators: %1$s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			$intro = sprintf( esc_html__( 'Grant %1$s access to this site.', 'trustedlogin' ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
+			$intro = sprintf( esc_html( $this->strings->get( Strings::GRANT_1_S_ACCESS_TO_THIS, __( 'Grant %1$s access to this site.', 'trustedlogin' ) ) ), '<a href="' . esc_url( $this->config->get_setting( 'vendor/website' ) ) . '">' . esc_html( $this->config->get_display_name() ) . '</a>' );
 		}
 
 		return $intro;
@@ -777,7 +761,7 @@ final class Form {
 					data-toggle=".tl-{{ns}}-ticket__fields">
 						%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span>
 				</span>',
-				esc_html__( 'Include a message for support?', 'trustedlogin' )
+				esc_html( $this->strings->get( Strings::INCLUDE_A_MESSAGE_FOR_SUPPORT, __( 'Include a message for support?', 'trustedlogin' ) ) )
 			);
 
 			$message_fields = sprintf(
@@ -792,7 +776,7 @@ final class Form {
 					></textarea>
 				</fieldset>
 			',
-				esc_html__( 'Please describe the issue you are having.', 'trustedlogin' )
+				esc_html( $this->strings->get( Strings::PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE, __( 'Please describe the issue you are having.', 'trustedlogin' ) ) )
 			);
 
 			$output_template .= $this->prepare_output(
@@ -819,25 +803,25 @@ final class Form {
 		}
 
 		// translators: %s is replaced with the of time that the login will be active for (e.g. "1 week").
-		$expire_summary = sprintf( esc_html__( 'Access this site for %s.', 'trustedlogin' ), '<strong>' . human_time_diff( 0, $this->config->get_setting( 'decay' ) ) . '</strong>' );
+		$expire_summary = sprintf( esc_html( $this->strings->get( Strings::ACCESS_THIS_SITE_FOR_S, __( 'Access this site for %s.', 'trustedlogin' ) ) ), '<strong>' . human_time_diff( 0, $this->config->get_setting( 'decay' ) ) . '</strong>' );
 
 		// translators: %s is replaced by the amount of time that the login will be active for (e.g. "1 week").
-		$expire_desc = '<small>' . sprintf( esc_html__( 'Access auto-expires in %s. You may revoke access at any time.', 'trustedlogin' ), human_time_diff( 0, $this->config->get_setting( 'decay' ) ) ) . '</small>';
+		$expire_desc = '<small>' . sprintf( esc_html( $this->strings->get( Strings::ACCESS_AUTO_EXPIRES_IN_S_YOU, __( 'Access auto-expires in %s. You may revoke access at any time.', 'trustedlogin' ) ) ), human_time_diff( 0, $this->config->get_setting( 'decay' ) ) ) . '</small>';
 
 		$cloned_role = translate_user_role( ucfirst( $this->config->get_setting( 'role' ) ) );
 
 		if ( $this->config->get_setting( 'clone_role' ) ) {
 
 			// translators: %s is replaced with the name of the role (e.g. "Administrator").
-			$roles_summary = sprintf( esc_html__( 'Create a user with a role based on %s.', 'trustedlogin' ), '<strong>' . $cloned_role . '</strong>' );
+			$roles_summary = sprintf( esc_html( $this->strings->get( Strings::CREATE_A_USER_WITH_A_ROLE, __( 'Create a user with a role based on %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
 
 			if ( $this->config->get_setting( 'caps/add' ) || $this->config->get_setting( 'caps/remove' ) ) {
-				$roles_summary .= sprintf( '<small class="tl-' . $ns . '-toggle" data-toggle=".tl-' . $ns . '-auth__role-container">%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span></small>', esc_html__( 'View modified role capabilities', 'trustedlogin' ) );
+				$roles_summary .= sprintf( '<small class="tl-' . $ns . '-toggle" data-toggle=".tl-' . $ns . '-auth__role-container">%s <span class="dashicons dashicons--small dashicons-arrow-down-alt2"></span></small>', esc_html( $this->strings->get( Strings::VIEW_MODIFIED_ROLE_CAPABILITIES, __( 'View modified role capabilities', 'trustedlogin' ) ) ) );
 			}
 		} else {
 
 			// translators: %s is replaced with the name of the role (e.g. "Administrator").
-			$roles_summary = sprintf( esc_html__( 'Create a user with a role of %s.', 'trustedlogin' ), '<strong>' . $cloned_role . '</strong>' );
+			$roles_summary = sprintf( esc_html( $this->strings->get( Strings::CREATE_A_USER_WITH_A_ROLE_60602c, __( 'Create a user with a role of %s.', 'trustedlogin' ) ) ), '<strong>' . $cloned_role . '</strong>' );
 		}
 
 		$content = array(
@@ -868,7 +852,7 @@ final class Form {
 		$output = sprintf(
 			'<h2><label><input type="checkbox" id="tl-{{ns}}-debug-data-consent" class="tl-{{ns}}-auth__checkbox--large" /> %s</label></h2>',
 			strtr(
-				esc_html__( 'Include the [link]Site Health[/link] troubleshooting report', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::INCLUDE_THE_LINK_SITE_HEALTH_LINK, __( 'Include the [link]Site Health[/link] troubleshooting report', 'trustedlogin' ) ) ),
 				array(
 					'[link]'  => '<a href="' . esc_url( admin_url( 'site-health.php?tab=debug' ) ) . '">',
 					'[/link]' => '</a>',
@@ -894,8 +878,8 @@ final class Form {
 		$removed = $this->config->get_setting( 'caps/remove' );
 
 		$caps  = '';
-		$caps .= $this->get_caps_section( $added, __( 'Additional capabilities:', 'trustedlogin' ), 'dashicons-yes-alt' );
-		$caps .= $this->get_caps_section( $removed, __( 'Removed capabilities:', 'trustedlogin' ), 'dashicons-dismiss' );
+		$caps .= $this->get_caps_section( $added, $this->strings->get( Strings::ADDITIONAL_CAPABILITIES, __( 'Additional capabilities:', 'trustedlogin' ) ), 'dashicons-yes-alt' );
+		$caps .= $this->get_caps_section( $removed, $this->strings->get( Strings::REMOVED_CAPABILITIES, __( 'Removed capabilities:', 'trustedlogin' ) ), 'dashicons-dismiss' );
 
 		if ( empty( $caps ) ) {
 			return $caps;
@@ -965,10 +949,10 @@ final class Form {
 
 		$content = array(
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			'local_site'            => sprintf( esc_html__( '%s support may not be able to access this site.', 'trustedlogin' ), $this->config->get_setting( 'vendor/title' ) ),
-			'need_access'           => esc_html__( 'This website is running in a local development environment. To provide support, we must be able to access your site using a publicly-accessible URL.', 'trustedlogin' ),
+			'local_site'            => sprintf( esc_html( $this->strings->get( Strings::S_SUPPORT_MAY_NOT_BE_ABLE, __( '%s support may not be able to access this site.', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) ),
+			'need_access'           => esc_html( $this->strings->get( Strings::THIS_WEBSITE_IS_RUNNING_IN_A, __( 'This website is running in a local development environment. To provide support, we must be able to access your site using a publicly-accessible URL.', 'trustedlogin' ) ) ),
 			'about_live_access_url' => esc_url( $this->config->get_setting( 'vendor/about_live_access_url', self::ABOUT_LIVE_ACCESS_URL ) ),
-			'learn_more'            => esc_html__( 'Learn more.', 'trustedlogin' ),
+			'learn_more'            => esc_html( $this->strings->get( Strings::LEARN_MORE, __( 'Learn more.', 'trustedlogin' ) ) ),
 		);
 
 		return $this->prepare_output( $notice_template, $content );
@@ -1021,7 +1005,7 @@ final class Form {
 		}
 
 		$footer_links = array(
-			esc_html__( 'Learn about TrustedLogin', 'trustedlogin' )                    => self::ABOUT_TL_URL,
+			esc_html( $this->strings->get( Strings::LEARN_ABOUT_TRUSTEDLOGIN, __( 'Learn about TrustedLogin', 'trustedlogin' ) ) )                    => self::ABOUT_TL_URL,
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
 			sprintf( 'Visit %s support', $this->config->get_setting( 'vendor/title' ) ) => $support_url,
 		);
@@ -1105,15 +1089,15 @@ final class Form {
 		};
 
 		$items = array(
-			esc_html__( 'TrustedLogin Status', 'trustedlogin' ) => sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( 'https://status.trustedlogin.com' ), is_wp_error( wp_remote_request( 'https://app.trustedlogin.com/api/status' ) ) ? esc_html__( 'Offline', 'trustedlogin' ) : esc_html__( 'Online', 'trustedlogin' ) ),
-			esc_html__( 'API Key', 'trustedlogin' )     => sprintf( '<code>%s</code>', esc_html( $mask( $api_key ) ) ),
-			esc_html__( 'License Key', 'trustedlogin' ) => sprintf( '<code>%s</code>', esc_html( $mask( $license_key ) ) ),
-			esc_html__( 'Log URL', 'trustedlogin' )     => '' === $log_url
-				? esc_html__( '(Log path is outside ABSPATH; not exposing as URL.)', 'trustedlogin' )
-				: sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( $log_url ), esc_html__( 'Download the log', 'trustedlogin' ) ),
-			esc_html__( 'Log Level', 'trustedlogin' )   => esc_html( (string) $this->config->get_setting( 'logging/threshold', __( '(Default)', 'trustedlogin' ) ) ),
-			esc_html__( 'Webhook URL', 'trustedlogin' ) => sprintf( '<code>%s</code>', esc_html( (string) $this->config->get_setting( 'webhook/url', '(Empty)' ) ) ),
-			esc_html__( 'Vendor Public Key', 'trustedlogin' ) => sprintf( '<code>%s</code> (<a href="%s" target="_blank">%s</a>)', esc_html( (string) $encryption->get_vendor_public_key() ), esc_url( (string) $encryption->get_remote_encryption_key_url() ), esc_html__( 'Verify key', 'trustedlogin' ) ),
+			esc_html( $this->strings->get( Strings::TRUSTEDLOGIN_STATUS, __( 'TrustedLogin Status', 'trustedlogin' ) ) ) => sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( 'https://status.trustedlogin.com' ), is_wp_error( wp_remote_request( 'https://app.trustedlogin.com/api/status' ) ) ? esc_html( $this->strings->get( Strings::OFFLINE, __( 'Offline', 'trustedlogin' ) ) ) : esc_html( $this->strings->get( Strings::ONLINE, __( 'Online', 'trustedlogin' ) ) ) ),
+			esc_html( $this->strings->get( Strings::API_KEY, __( 'API Key', 'trustedlogin' ) ) )     => sprintf( '<code>%s</code>', esc_html( $mask( $api_key ) ) ),
+			esc_html( $this->strings->get( Strings::LICENSE_KEY, __( 'License Key', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code>', esc_html( $mask( $license_key ) ) ),
+			esc_html( $this->strings->get( Strings::LOG_URL, __( 'Log URL', 'trustedlogin' ) ) )     => '' === $log_url
+				? esc_html( $this->strings->get( Strings::LOG_PATH_IS_OUTSIDE_ABSPATH_NOT, __( '(Log path is outside ABSPATH; not exposing as URL.)', 'trustedlogin' ) ) )
+				: sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_url( $log_url ), esc_html( $this->strings->get( Strings::DOWNLOAD_THE_LOG, __( 'Download the log', 'trustedlogin' ) ) ) ),
+			esc_html( $this->strings->get( Strings::LOG_LEVEL, __( 'Log Level', 'trustedlogin' ) ) )   => esc_html( (string) $this->config->get_setting( 'logging/threshold', $this->strings->get( Strings::DEFAULT, __( '(Default)', 'trustedlogin' ) ) ) ),
+			esc_html( $this->strings->get( Strings::WEBHOOK_URL, __( 'Webhook URL', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code>', esc_html( (string) $this->config->get_setting( 'webhook/url', '(Empty)' ) ) ),
+			esc_html( $this->strings->get( Strings::VENDOR_PUBLIC_KEY, __( 'Vendor Public Key', 'trustedlogin' ) ) ) => sprintf( '<code>%s</code> (<a href="%s" target="_blank">%s</a>)', esc_html( (string) $encryption->get_vendor_public_key() ), esc_url( (string) $encryption->get_remote_encryption_key_url() ), esc_html( $this->strings->get( Strings::VERIFY_KEY, __( 'Verify key', 'trustedlogin' ) ) ) ),
 		);
 
 		$debugging_info = '';
@@ -1152,9 +1136,9 @@ final class Form {
 			$debugging_output,
 			array(
 				'ns'              => $this->config->ns(),
-				'debugging_label' => esc_html__( 'Debugging Info', 'trustedlogin' ),
+				'debugging_label' => esc_html( $this->strings->get( Strings::DEBUGGING_INFO, __( 'Debugging Info', 'trustedlogin' ) ) ),
 				'debugging_info'  => $debugging_info,
-				'tl_config_label' => esc_html__( 'TrustedLogin Config', 'trustedlogin' ),
+				'tl_config_label' => esc_html( $this->strings->get( Strings::TRUSTEDLOGIN_CONFIG, __( 'TrustedLogin Config', 'trustedlogin' ) ) ),
 				'tl_config'       => '<pre>' . esc_html( print_r( $config_dump, true ) ) . '</pre>', // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			)
 		);
@@ -1451,9 +1435,9 @@ final class Form {
 
 		$defaults = array(
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			'text'        => sprintf( esc_html__( 'Grant %s Access', 'trustedlogin' ), $this->config->get_display_name() ),
+			'text'        => sprintf( esc_html( $this->strings->get( Strings::GRANT_S_ACCESS, __( 'Grant %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name() ),
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			'exists_text' => sprintf( esc_html__( 'Extend %s Access', 'trustedlogin' ), $this->config->get_display_name(), ucwords( human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ) ),
+			'exists_text' => sprintf( esc_html( $this->strings->get( Strings::EXTEND_S_ACCESS, __( 'Extend %s Access', 'trustedlogin' ) ) ), $this->config->get_display_name(), ucwords( human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ) ),
 			'size'        => 'hero',
 			'class'       => 'button-primary',
 			'tag'         => 'a', // Inline tags only.
@@ -1517,7 +1501,7 @@ final class Form {
 		if ( $atts['powered_by'] ) {
 			$powered_by = sprintf(
 				'<small><span class="trustedlogin-logo"></span>%s</small>',
-				esc_html__( 'Secured by TrustedLogin', 'trustedlogin' )
+				esc_html( $this->strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, __( 'Secured by TrustedLogin', 'trustedlogin' ) ) )
 			);
 		}
 
@@ -1592,7 +1576,7 @@ final class Form {
 		$query_args = apply_filters(
 			'trustedlogin/' . $this->config->ns() . '/support_url/query_args',
 			array(
-				'message' => __( 'Could not create support access.', 'trustedlogin' ),
+				'message' => $this->strings->get( Strings::COULD_NOT_CREATE_SUPPORT_ACCESS, __( 'Could not create support access.', 'trustedlogin' ) ),
 				'ref'     => Client::get_reference_id(),
 			)
 		);
@@ -1601,12 +1585,12 @@ final class Form {
 			'<p>%s</p><p>%s</p>',
 			sprintf(
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-				esc_html__( 'The user details could not be sent to %1$s automatically.', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::THE_USER_DETAILS_COULD_NOT_BE, __( 'The user details could not be sent to %1$s automatically.', 'trustedlogin' ) ) ),
 				$vendor_title
 			),
 			sprintf(
 			// translators: %1$s is the vendor support url and %2$s is the vendor title.
-				__( 'Please <a href="%1$s" target="_blank">click here</a> to go to the %2$s support site', 'trustedlogin' ),
+				$this->strings->get( Strings::PLEASE_A_HREF_1_S_TARGET, __( 'Please <a href="%1$s" target="_blank">click here</a> to go to the %2$s support site', 'trustedlogin' ) ),
 				esc_url( add_query_arg( $query_args, $this->config->get_setting( 'vendor/support_url' ) ) ),
 				$vendor_title
 			)
@@ -1614,45 +1598,45 @@ final class Form {
 
 		$translations = array(
 			'buttons' => array(
-				'confirm'    => esc_html__( 'Confirm', 'trustedlogin' ),
-				'ok'         => esc_html__( 'Ok', 'trustedlogin' ),
+				'confirm'    => esc_html( $this->strings->get( Strings::CONFIRM, __( 'Confirm', 'trustedlogin' ) ) ),
+				'ok'         => esc_html( $this->strings->get( Strings::OK, __( 'Ok', 'trustedlogin' ) ) ),
 				// translators: %1$s is the vendor title.
-				'go_to_site' => sprintf( __( 'Go to %1$s support site', 'trustedlogin' ), $vendor_title ),
-				'close'      => esc_html__( 'Close', 'trustedlogin' ),
-				'cancel'     => esc_html__( 'Cancel', 'trustedlogin' ),
+				'go_to_site' => sprintf( $this->strings->get( Strings::GO_TO_1_S_SUPPORT_SITE, __( 'Go to %1$s support site', 'trustedlogin' ) ), $vendor_title ),
+				'close'      => esc_html( $this->strings->get( Strings::CLOSE, __( 'Close', 'trustedlogin' ) ) ),
+				'cancel'     => esc_html( $this->strings->get( Strings::CANCEL, __( 'Cancel', 'trustedlogin' ) ) ),
 				// translators: %1$s is the vendor title.
-				'revoke'     => sprintf( esc_html__( 'Revoke %1$s support access', 'trustedlogin' ), $vendor_title ),
-				'copy'       => esc_html__( 'Copy', 'trustedlogin' ),
-				'copied'     => esc_html__( 'Copied!', 'trustedlogin' ),
+				'revoke'     => sprintf( esc_html( $this->strings->get( Strings::REVOKE_1_S_SUPPORT_ACCESS, __( 'Revoke %1$s support access', 'trustedlogin' ) ) ), $vendor_title ),
+				'copy'       => esc_html( $this->strings->get( Strings::COPY, __( 'Copy', 'trustedlogin' ) ) ),
+				'copied'     => esc_html( $this->strings->get( Strings::COPIED, __( 'Copied!', 'trustedlogin' ) ) ),
 			),
 			'a11y'    => array(
-				'opens_new_window' => esc_attr__( '(This link opens in a new window.)', 'trustedlogin' ),
-				'copied_text'      => esc_html__( 'The access key has been copied to your clipboard.', 'trustedlogin' ),
+				'opens_new_window' => esc_attr( $this->strings->get( Strings::THIS_LINK_OPENS_IN_A_NEW, __( '(This link opens in a new window.)', 'trustedlogin' ) ) ),
+				'copied_text'      => esc_html( $this->strings->get( Strings::THE_ACCESS_KEY_HAS_BEEN_COPIED, __( 'The access key has been copied to your clipboard.', 'trustedlogin' ) ) ),
 			),
 			'status'  => array(
 				'synced'             => array(
-					'title'   => esc_html__( 'Support access granted', 'trustedlogin' ),
+					'title'   => esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_GRANTED, __( 'Support access granted', 'trustedlogin' ) ) ),
 					'content' => sprintf(
 					// translators: %1$s is the vendor title.
-						__( 'A temporary support user has been created, and sent to %1$s support.', 'trustedlogin' ),
+						$this->strings->get( Strings::A_TEMPORARY_SUPPORT_USER_HAS_BEEN, __( 'A temporary support user has been created, and sent to %1$s support.', 'trustedlogin' ) ),
 						$vendor_title
 					),
 				),
 				'pending'            => array(
 					// translators: %1$s is the vendor title.
-					'content' => sprintf( __( 'Generating & encrypting secure support access for %1$s', 'trustedlogin' ), $vendor_title ),
+					'content' => sprintf( $this->strings->get( Strings::GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR, __( 'Generating & encrypting secure support access for %1$s', 'trustedlogin' ) ), $vendor_title ),
 				),
 				'extending'          => array(
 					// translators: %1$s is the vendor title and %2$s is the human-readable expiration time (for example, "1 week").
-					'content' => sprintf( __( 'Extending support access for %1$s by %2$s', 'trustedlogin' ), $vendor_title, human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ),
+					'content' => sprintf( $this->strings->get( Strings::EXTENDING_SUPPORT_ACCESS_FOR_1_S, __( 'Extending support access for %1$s by %2$s', 'trustedlogin' ) ), $vendor_title, human_time_diff( time(), time() + (int) $this->config->get_setting( 'decay' ) ) ),
 				),
 				'syncing'            => array(
 					// translators: %1$s is the vendor title.
-					'content' => sprintf( __( 'Sending encrypted access to %1$s.', 'trustedlogin' ), $vendor_title ),
+					'content' => sprintf( $this->strings->get( Strings::SENDING_ENCRYPTED_ACCESS_TO_1_S, __( 'Sending encrypted access to %1$s.', 'trustedlogin' ) ), $vendor_title ),
 				),
 				'error'              => array(
 					// translators: %1$s is the vendor title.
-					'title'   => sprintf( __( 'Couldn\'t register support access with %1$s', 'trustedlogin' ), $vendor_title ),
+					'title'   => sprintf( $this->strings->get( Strings::COULDN_T_REGISTER_SUPPORT_ACCESS_WITH, __( 'Couldn\'t register support access with %1$s', 'trustedlogin' ) ), $vendor_title ),
 					'content' => wp_kses(
 						$error_content,
 						array(
@@ -1666,46 +1650,46 @@ final class Form {
 					),
 				),
 				'cancel'             => array(
-					'title'   => esc_html__( 'Action Cancelled', 'trustedlogin' ),
+					'title'   => esc_html( $this->strings->get( Strings::ACTION_CANCELLED, __( 'Action Cancelled', 'trustedlogin' ) ) ),
 					'content' => sprintf(
 					// translators: %1$s is the vendor title.
-						__( 'A support account for %1$s was not created.', 'trustedlogin' ),
+						$this->strings->get( Strings::A_SUPPORT_ACCOUNT_FOR_1_S, __( 'A support account for %1$s was not created.', 'trustedlogin' ) ),
 						$vendor_title
 					),
 				),
 				'failed'             => array(
-					'title'   => esc_html__( 'Support Access Was Not Granted', 'trustedlogin' ),
-					'content' => esc_html__( 'There was an error granting access: ', 'trustedlogin' ),
+					'title'   => esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_WAS_NOT_GRANTED, __( 'Support Access Was Not Granted', 'trustedlogin' ) ) ),
+					'content' => esc_html( $this->strings->get( Strings::THERE_WAS_AN_ERROR_GRANTING_ACCESS, __( 'There was an error granting access: ', 'trustedlogin' ) ) ),
 				),
 				'failed_permissions' => array(
-					'content' => esc_html__( 'Your authorized session has expired. Please refresh the page.', 'trustedlogin' ),
+					'content' => esc_html( $this->strings->get( Strings::YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE, __( 'Your authorized session has expired. Please refresh the page.', 'trustedlogin' ) ) ),
 				),
 				'timeout'            => array(
-					'content' => esc_html__( 'The request took too long to complete. Please try again.', 'trustedlogin' ),
+					'content' => esc_html( $this->strings->get( Strings::THE_REQUEST_TOOK_TOO_LONG_TO, __( 'The request took too long to complete. Please try again.', 'trustedlogin' ) ) ),
 				),
 				'accesskey'          => array(
-					'title'       => esc_html__( 'Support Access Key Created', 'trustedlogin' ),
+					'title'       => esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_KEY_CREATED, __( 'Support Access Key Created', 'trustedlogin' ) ) ),
 					'content'     => sprintf(
 					// translators: %1$s is the vendor title.
-						__( 'Share this access key with %1$s to give them secure access:', 'trustedlogin' ),
+						$this->strings->get( Strings::SHARE_THIS_ACCESS_KEY_WITH_1, __( 'Share this access key with %1$s to give them secure access:', 'trustedlogin' ) ),
 						$vendor_title
 					),
 					'revoke_link' => esc_url( add_query_arg( array( Endpoint::REVOKE_SUPPORT_QUERY_PARAM => $this->config->ns() ), admin_url() ) ),
 				),
 				'error404'           => array(
-					'title'   => esc_html__( 'The support team\'s site could not be found.', 'trustedlogin' ),
+					'title'   => esc_html( $this->strings->get( Strings::THE_SUPPORT_TEAM_S_SITE_COULD, __( 'The support team\'s site could not be found.', 'trustedlogin' ) ) ),
 					'content' => '',
 				),
 				'error409'           => array(
 					'title'   => sprintf(
 					// translators: %1$s is the vendor title.
-						__( '%1$s Support user already exists', 'trustedlogin' ),
+						$this->strings->get( Strings::VENDOR_SUPPORT_USER_ALREADY_EXISTS, __( '%1$s Support user already exists', 'trustedlogin' ) ),
 						$vendor_title
 					),
 					'content' => sprintf(
 						wp_kses(
 						// translators: %1$s is the vendor title, %2$s is the URL to the users list page.
-							__( 'A support user for %1$s already exists. You may revoke this support access from your <a href="%2$s" target="_blank">Users list</a>.', 'trustedlogin' ),
+							$this->strings->get( Strings::A_SUPPORT_USER_FOR_1_S, __( 'A support user for %1$s already exists. You may revoke this support access from your <a href="%2$s" target="_blank">Users list</a>.', 'trustedlogin' ) ),
 							array(
 								'a' => array(
 									'href'   => array(),
@@ -1748,7 +1732,7 @@ final class Form {
 		if ( empty( $support_users ) ) {
 
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			$return = '<h3>' . sprintf( esc_html__( 'No %s users exist.', 'trustedlogin' ), esc_html( $this->config->get_setting( 'vendor/title' ) ) ) . '</h3>';
+			$return = '<h3>' . sprintf( esc_html( $this->strings->get( Strings::NO_S_USERS_EXIST, __( 'No %s users exist.', 'trustedlogin' ) ) ), esc_html( $this->config->get_setting( 'vendor/title' ) ) ) . '</h3>';
 
 			if ( $print_and_return ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -1774,11 +1758,11 @@ EOD;
 				/* %1$s */
 				sanitize_title( $this->config->ns() ),
 				/* %2$s */
-				esc_html__( 'Error', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::ERROR, __( 'Error', 'trustedlogin' ) ) ),
 				/* %3$s */
 				'div',
 				/* %4$s */
-				esc_html__( 'There was an error returning the access key.', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::THERE_WAS_AN_ERROR_RETURNING_THE, __( 'There was an error returning the access key.', 'trustedlogin' ) ) ),
 				/* %5$s */
 				esc_html( $access_key->get_error_message() )
 			);
@@ -1800,20 +1784,20 @@ EOD;
 				/* %1$s */
 				sanitize_title( $this->config->ns() ),
 				/* %2$s */
-				esc_html__( 'Site access key:', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::SITE_ACCESS_KEY, __( 'Site access key:', 'trustedlogin' ) ) ),
 				/* %3$s */
-				esc_html__( 'Access Key', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::ACCESS_KEY, __( 'Access Key', 'trustedlogin' ) ) ),
 				/* %4$s */
 				esc_attr( $access_key ),
 				/* %5$s */
-				esc_html__( 'Copy', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::COPY, __( 'Copy', 'trustedlogin' ) ) ),
 				/* %6$s */
 				'div',
 				/* %7$s */
-				esc_html__( 'Copy the access key to your clipboard', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::COPY_THE_ACCESS_KEY_TO_YOUR, __( 'Copy the access key to your clipboard', 'trustedlogin' ) ) ),
 				// %8$s
 				// translators: %s is the display name of the TrustedLogin support user.
-				sprintf( esc_html__( 'The access key is not a password; only %1$s will be able to access your site using this code. You may share this access key on support forums.', 'trustedlogin' ), esc_html( $this->support_user->get_first()->display_name ) ),
+				sprintf( esc_html( $this->strings->get( Strings::THE_ACCESS_KEY_IS_NOT_A, __( 'The access key is not a password; only %1$s will be able to access your site using this code. You may share this access key on support forums.', 'trustedlogin' ) ) ), esc_html( $this->support_user->get_first()->display_name ) ),
 				/* %9$s */
 				esc_attr( $this->support_user->get_expiration( $this->support_user->get_first() ) )
 			);
@@ -1873,7 +1857,7 @@ EOD;
 					echo esc_html(
 						sprintf(
 						// translators: %s vendor title (e.g. Acme Widgets).
-							__( 'You are logged in as a %s support user.', 'trustedlogin' ),
+							$this->strings->get( Strings::YOU_ARE_LOGGED_IN_AS_A_4eed50, __( 'You are logged in as a %s support user.', 'trustedlogin' ) ),
 							$vendor_title
 						)
 					);
@@ -1885,7 +1869,7 @@ EOD;
 						echo esc_html(
 							sprintf(
 							// translators: %s human-readable duration like "1 week".
-								__( 'Access expires in %s.', 'trustedlogin' ),
+								$this->strings->get( Strings::ACCESS_EXPIRES_IN_S, __( 'Access expires in %s.', 'trustedlogin' ) ),
 								$expiration
 							)
 						);
@@ -1907,7 +1891,7 @@ EOD;
 					<?php
 					printf(
 						/* translators: %s: the currently signed-in user's display name */
-						esc_html__( 'You were already signed in as %s, so the support login was skipped. You can grant or revoke access as usual.', 'trustedlogin' ),
+						esc_html( $this->strings->get( Strings::YOU_WERE_ALREADY_SIGNED_IN_AS, __( 'You were already signed in as %s, so the support login was skipped. You can grant or revoke access as usual.', 'trustedlogin' ) ) ),
 						esc_html( wp_get_current_user()->display_name )
 					);
 					?>
@@ -1936,11 +1920,11 @@ EOD;
 			<h3>
 			<?php
 				// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-				echo esc_html( sprintf( __( '%s access revoked.', 'trustedlogin' ), $this->config->get_setting( 'vendor/title' ) ) );
+				echo esc_html( sprintf( $this->strings->get( Strings::S_ACCESS_REVOKED, __( '%s access revoked.', 'trustedlogin' ) ), $this->config->get_setting( 'vendor/title' ) ) );
 			?>
 				</h3>
 			<?php if ( ! current_user_can( 'delete_users' ) ) { ?>
-				<p><?php echo esc_html__( 'You may safely close this window.', 'trustedlogin' ); ?></p>
+				<p><?php echo esc_html( $this->strings->get( Strings::YOU_MAY_SAFELY_CLOSE_THIS_WINDOW, __( 'You may safely close this window.', 'trustedlogin' ) ) ); ?></p>
 			<?php } ?>
 		</div>
 		<?php

--- a/src/Form.php
+++ b/src/Form.php
@@ -62,6 +62,11 @@ final class Form {
 	private $logging;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Form constructor.
 	 *
 	 * @param Config      $config Config object.
@@ -74,6 +79,7 @@ final class Form {
 		$this->logging      = $logging;
 		$this->support_user = $support_user;
 		$this->site_access  = $site_access;
+		$this->strings      = new Strings( $config );
 	}
 
 	/**
@@ -313,9 +319,18 @@ final class Form {
 		// closing the same gap on the auth header path.
 		$content = array(
 			'display_name'         => esc_html( $support_user->display_name ),
-			'revoke_access_button' => sprintf( '<a href="%1$s" class="button button-danger alignright tl-client-revoke-button">%2$s</a>', esc_url( $revoke_url ), esc_html__( 'Revoke Access', 'trustedlogin' ) ),
+			'revoke_access_button' => sprintf(
+				'<a href="%1$s" class="button button-danger alignright tl-client-revoke-button">%2$s</a>',
+				esc_url( $revoke_url ),
+				esc_html( $this->strings->get( Strings::REVOKE_ACCESS_BUTTON, __( 'Revoke Access', 'trustedlogin' ) ) )
+			),
 			// translators: %s is the display name of the user who granted access.
-			'auth_meta'            => sprintf( esc_html__( 'Created %1$s ago by %2$s', 'trustedlogin' ), esc_html( human_time_diff( strtotime( $support_user->user_registered ) ) ), esc_html( $auth_meta ) ),
+			'auth_meta'            => sprintf(
+				/* translators: %1$s: human-readable time ago; %2$s: display name of the user who granted access */
+				esc_html( $this->strings->get( Strings::CREATED_TIME_AGO, __( 'Created %1$s ago by %2$s', 'trustedlogin' ) ) ),
+				esc_html( human_time_diff( strtotime( $support_user->user_registered ) ) ),
+				esc_html( $auth_meta )
+			),
 		);
 
 		return $this->prepare_output( $template, $content );
@@ -390,7 +405,12 @@ final class Form {
 
 		$message = $error->get_error_message();
 		if ( '' === $message ) {
-			$message = esc_html__( 'Support access is temporarily unavailable. Please try again in a few minutes.', 'trustedlogin' );
+			$message = esc_html(
+				$this->strings->get(
+					Strings::SUPPORT_TEMPORARILY_UNAVAILABLE,
+					__( 'Support access is temporarily unavailable. Please try again in a few minutes.', 'trustedlogin' )
+				)
+			);
 		}
 
 		$response_html = sprintf(
@@ -413,7 +433,7 @@ final class Form {
 			'<p class="tl-%1$s-auth__retry-wrap"><a class="tl-%1$s-auth__retry" href="%2$s"><span class="dashicons dashicons-update" aria-hidden="true"></span> %3$s</a></p>',
 			esc_attr( $ns ),
 			esc_url( $retry_url ),
-			esc_html__( 'Try reconnecting', 'trustedlogin' )
+			esc_html( $this->strings->get( Strings::TRY_RECONNECTING, __( 'Try reconnecting', 'trustedlogin' ) ) )
 		);
 
 		return array(
@@ -493,7 +513,9 @@ final class Form {
 			'response'                => $response_html,
 			'actions'                 => $actions_html,
 			'actions_container_class' => $grant_container,
-			'secured_by_trustedlogin' => '<span class="trustedlogin-logo-medium"></span>' . esc_html__( 'Secured by TrustedLogin', 'trustedlogin' ),
+			'secured_by_trustedlogin' => '<span class="trustedlogin-logo-medium"></span>' . esc_html(
+				$this->strings->get( Strings::SECURED_BY, __( 'Secured by TrustedLogin', 'trustedlogin' ) )
+			),
 			'footer'                  => $this->get_footer_html(),
 			'reference'               => $this->get_reference_html(),
 			'admin_debug'             => $this->get_admin_debug_html(),

--- a/src/Remote.php
+++ b/src/Remote.php
@@ -38,11 +38,6 @@ final class Remote {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Logging object.
 	 *
 	 * @var Logging $logging
@@ -57,7 +52,6 @@ final class Remote {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config  = $config;
-		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 	}
 
@@ -596,22 +590,22 @@ final class Remote {
 
 			case 400:
 			case 423:
-				return new \WP_Error( 'unable_to_verify', esc_html__( 'Support access could not be set up right now. Please try again in a few minutes, or contact the plugin\'s support team.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'unable_to_verify', esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_979c0f, __( 'Support access could not be set up right now. Please try again in a few minutes, or contact the plugin\'s support team.', 'trustedlogin' ) ) ), $api_response );
 
 			case 401:
-				return new \WP_Error( 'unauthenticated', esc_html__( 'Support access could not be verified. Please contact the plugin\'s support team.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'unauthenticated', esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED, __( 'Support access could not be verified. Please contact the plugin\'s support team.', 'trustedlogin' ) ) ), $api_response );
 
 			case 402:
-				return new \WP_Error( 'account_error', esc_html__( 'The support team\'s account has an issue that\'s preventing access. Please contact them directly.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'account_error', esc_html( Strings::get( Strings::THE_SUPPORT_TEAM_S_ACCOUNT_HAS, __( 'The support team\'s account has an issue that\'s preventing access. Please contact them directly.', 'trustedlogin' ) ) ), $api_response );
 
 			case 403:
-				return new \WP_Error( 'invalid_token', esc_html__( 'Support access was refused. Please contact the plugin\'s support team.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'invalid_token', esc_html( Strings::get( Strings::SUPPORT_ACCESS_WAS_REFUSED_PLEASE_CONTACT, __( 'Support access was refused. Please contact the plugin\'s support team.', 'trustedlogin' ) ) ), $api_response );
 
 			// The vendor-side endpoint returned 404. Most often: Connector
 			// not installed on the vendor site, or the REST route is
 			// disabled by a security plugin on the vendor.
 			case 404:
-				return new \WP_Error( 'not_found', esc_html__( 'The support team\'s site is not ready to receive access requests. Please contact their support team and let them know.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'not_found', esc_html( Strings::get( Strings::THE_SUPPORT_TEAM_S_SITE_IS, __( 'The support team\'s site is not ready to receive access requests. Please contact their support team and let them know.', 'trustedlogin' ) ) ), $api_response );
 
 			case 418:
 				return new \WP_Error( 'teapot', '🫖', $api_response );
@@ -621,19 +615,19 @@ final class Remote {
 			case 500:
 			case 503:
 			case 'http_request_failed':
-				return new \WP_Error( 'unavailable', esc_html__( 'The support team\'s site is temporarily unreachable. Please try again in a few minutes.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'unavailable', esc_html( Strings::get( Strings::THE_SUPPORT_TEAM_S_SITE_IS_6d0ab1, __( 'The support team\'s site is temporarily unreachable. Please try again in a few minutes.', 'trustedlogin' ) ) ), $api_response );
 
 			// Vendor returned a 501/502/522 — server-side error on their
 			// end. Retrying likely won't help until they fix it.
 			case 501:
 			case 502:
 			case 522:
-				return new \WP_Error( 'server_error', esc_html__( 'The support team\'s site returned an error. Please contact their support team directly.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'server_error', esc_html( Strings::get( Strings::THE_SUPPORT_TEAM_S_SITE_RETURNED, __( 'The support team\'s site returned an error. Please contact their support team directly.', 'trustedlogin' ) ) ), $api_response );
 
 			// wp_remote_retrieve_response_code() couldn't parse the
 			// response at all — network layer failure.
 			case '':
-				return new \WP_Error( 'invalid_response', esc_html__( 'Could not reach the support team\'s site. Please check your internet connection and try again.', 'trustedlogin' ), $api_response );
+				return new \WP_Error( 'invalid_response', esc_html( Strings::get( Strings::COULD_NOT_REACH_THE_SUPPORT_TEAM, __( 'Could not reach the support team\'s site. Please check your internet connection and try again.', 'trustedlogin' ) ) ), $api_response );
 
 			// Any response code we don't explicitly map. Preserve the
 			// HTTP status in the returned WP_Error so the UI / logs can
@@ -652,7 +646,7 @@ final class Remote {
 					'unexpected_response_code',
 					sprintf(
 						/* translators: %d: the HTTP status code returned by the vendor site */
-						esc_html__( 'Support access could not be set up (HTTP %d). Please contact the plugin\'s support team and share this number.', 'trustedlogin' ),
+						esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_084a44, __( 'Support access could not be set up (HTTP %d). Please contact the plugin\'s support team and share this number.', 'trustedlogin' ) ) ),
 						$status
 					),
 					array(
@@ -734,7 +728,7 @@ final class Remote {
 			'vendor_response_not_json',
 			sprintf(
 				/* translators: %d: the HTTP status code returned by the support team's site */
-				esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_829416, __( 'Support access could not be set up. A firewall on the plugin\'s support team\'s site blocked the request (HTTP %d). Please contact them and let them know — they\'ll need to allowlist this site or check their firewall logs.', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_829416, __( 'Support access could not be set up. A firewall on the plugin\'s support team\'s site blocked the request (HTTP %d). Please contact them and let them know — they\'ll need to allowlist this site or check their firewall logs.', 'trustedlogin' ) ) ),
 				$status
 			),
 			array(
@@ -794,7 +788,7 @@ final class Remote {
 
 			return new \WP_Error(
 				'missing_response_body',
-				esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING, __( 'Support access could not be set up. The plugin\'s support team\'s site returned nothing — a firewall on their side may have blocked the request. Please contact them and share this error.', 'trustedlogin' ) ) ),
+				esc_html( Strings::get( Strings::SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING, __( 'Support access could not be set up. The plugin\'s support team\'s site returned nothing — a firewall on their side may have blocked the request. Please contact them and share this error.', 'trustedlogin' ) ) ),
 				$api_response
 			);
 		}
@@ -816,7 +810,7 @@ final class Remote {
 				'invalid_response',
 				sprintf(
 					/* translators: %d: the HTTP status code returned by the support team's site */
-					esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_343150, __( 'Support access could not be set up — the plugin\'s support team\'s site returned an unexpected response (HTTP %d). Please contact them and share this error.', 'trustedlogin' ) ) ),
+					esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_343150, __( 'Support access could not be set up — the plugin\'s support team\'s site returned an unexpected response (HTTP %d). Please contact them and share this error.', 'trustedlogin' ) ) ),
 					$response_http
 				),
 				$api_response
@@ -855,14 +849,14 @@ final class Remote {
 
 					return new \WP_Error(
 						'missing_public_key',
-						esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED, __( 'Support access could not be set up. The plugin\'s support team needs to finish configuring their end — please contact them and let them know.', 'trustedlogin' ) ) ),
+						esc_html( Strings::get( Strings::SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED, __( 'Support access could not be set up. The plugin\'s support team needs to finish configuring their end — please contact them and let them know.', 'trustedlogin' ) ) ),
 						$response_body
 					);
 				}
 
 				return new \WP_Error(
 					'missing_required_key',
-					esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE, __( 'Support access could not be set up. The plugin\'s support team\'s response was incomplete — please contact them and share this error.', 'trustedlogin' ) ) ),
+					esc_html( Strings::get( Strings::SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE, __( 'Support access could not be set up. The plugin\'s support team\'s response was incomplete — please contact them and share this error.', 'trustedlogin' ) ) ),
 					$response_body
 				);
 			}

--- a/src/Remote.php
+++ b/src/Remote.php
@@ -38,6 +38,11 @@ final class Remote {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Logging object.
 	 *
 	 * @var Logging $logging
@@ -52,6 +57,7 @@ final class Remote {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config  = $config;
+		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 	}
 
@@ -728,7 +734,7 @@ final class Remote {
 			'vendor_response_not_json',
 			sprintf(
 				/* translators: %d: the HTTP status code returned by the support team's site */
-				esc_html__( 'Support access could not be set up. A firewall on the plugin\'s support team\'s site blocked the request (HTTP %d). Please contact them and let them know — they\'ll need to allowlist this site or check their firewall logs.', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_829416, __( 'Support access could not be set up. A firewall on the plugin\'s support team\'s site blocked the request (HTTP %d). Please contact them and let them know — they\'ll need to allowlist this site or check their firewall logs.', 'trustedlogin' ) ) ),
 				$status
 			),
 			array(
@@ -788,7 +794,7 @@ final class Remote {
 
 			return new \WP_Error(
 				'missing_response_body',
-				esc_html__( 'Support access could not be set up. The plugin\'s support team\'s site returned nothing — a firewall on their side may have blocked the request. Please contact them and share this error.', 'trustedlogin' ),
+				esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING, __( 'Support access could not be set up. The plugin\'s support team\'s site returned nothing — a firewall on their side may have blocked the request. Please contact them and share this error.', 'trustedlogin' ) ) ),
 				$api_response
 			);
 		}
@@ -810,7 +816,7 @@ final class Remote {
 				'invalid_response',
 				sprintf(
 					/* translators: %d: the HTTP status code returned by the support team's site */
-					esc_html__( 'Support access could not be set up — the plugin\'s support team\'s site returned an unexpected response (HTTP %d). Please contact them and share this error.', 'trustedlogin' ),
+					esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_343150, __( 'Support access could not be set up — the plugin\'s support team\'s site returned an unexpected response (HTTP %d). Please contact them and share this error.', 'trustedlogin' ) ) ),
 					$response_http
 				),
 				$api_response
@@ -849,14 +855,14 @@ final class Remote {
 
 					return new \WP_Error(
 						'missing_public_key',
-						esc_html__( 'Support access could not be set up. The plugin\'s support team needs to finish configuring their end — please contact them and let them know.', 'trustedlogin' ),
+						esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED, __( 'Support access could not be set up. The plugin\'s support team needs to finish configuring their end — please contact them and let them know.', 'trustedlogin' ) ) ),
 						$response_body
 					);
 				}
 
 				return new \WP_Error(
 					'missing_required_key',
-					esc_html__( 'Support access could not be set up. The plugin\'s support team\'s response was incomplete — please contact them and share this error.', 'trustedlogin' ),
+					esc_html( $this->strings->get( Strings::SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE, __( 'Support access could not be set up. The plugin\'s support team\'s response was incomplete — please contact them and share this error.', 'trustedlogin' ) ) ),
 					$response_body
 				);
 			}

--- a/src/Remote.php
+++ b/src/Remote.php
@@ -590,7 +590,7 @@ final class Remote {
 
 			case 400:
 			case 423:
-				return new \WP_Error( 'unable_to_verify', esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_979c0f, __( 'Support access could not be set up right now. Please try again in a few minutes, or contact the plugin\'s support team.', 'trustedlogin' ) ) ), $api_response );
+				return new \WP_Error( 'unable_to_verify', esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_979C0F, __( 'Support access could not be set up right now. Please try again in a few minutes, or contact the plugin\'s support team.', 'trustedlogin' ) ) ), $api_response );
 
 			case 401:
 				return new \WP_Error( 'unauthenticated', esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED, __( 'Support access could not be verified. Please contact the plugin\'s support team.', 'trustedlogin' ) ) ), $api_response );
@@ -615,7 +615,7 @@ final class Remote {
 			case 500:
 			case 503:
 			case 'http_request_failed':
-				return new \WP_Error( 'unavailable', esc_html( Strings::get( Strings::THE_SUPPORT_TEAM_S_SITE_IS_6d0ab1, __( 'The support team\'s site is temporarily unreachable. Please try again in a few minutes.', 'trustedlogin' ) ) ), $api_response );
+				return new \WP_Error( 'unavailable', esc_html( Strings::get( Strings::THE_SUPPORT_TEAM_S_SITE_IS_6D0AB1, __( 'The support team\'s site is temporarily unreachable. Please try again in a few minutes.', 'trustedlogin' ) ) ), $api_response );
 
 			// Vendor returned a 501/502/522 — server-side error on their
 			// end. Retrying likely won't help until they fix it.
@@ -646,7 +646,7 @@ final class Remote {
 					'unexpected_response_code',
 					sprintf(
 						/* translators: %d: the HTTP status code returned by the vendor site */
-						esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_084a44, __( 'Support access could not be set up (HTTP %d). Please contact the plugin\'s support team and share this number.', 'trustedlogin' ) ) ),
+						esc_html( Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_SET_084A44, __( 'Support access could not be set up (HTTP %d). Please contact the plugin\'s support team and share this number.', 'trustedlogin' ) ) ),
 						$status
 					),
 					array(

--- a/src/SecurityChecks.php
+++ b/src/SecurityChecks.php
@@ -33,6 +33,11 @@ final class SecurityChecks {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * The transient slug used for storing used accesskeys.
 	 *
 	 * @var string
@@ -91,6 +96,7 @@ final class SecurityChecks {
 
 		$this->logging = $logging;
 		$this->config  = $config;
+		$this->strings = new Strings( $config );
 
 		$this->used_accesskey_transient = 'tl-' . $this->config->ns() . '-used_accesskeys';
 		$this->in_lockdown_transient    = 'tl-' . $this->config->ns() . '-in_lockdown';
@@ -112,7 +118,7 @@ final class SecurityChecks {
 		if ( $this->in_lockdown() ) {
 			$this->logging->log( 'Site is in lockdown mode, aborting login.', __METHOD__, 'error' );
 
-			return new \WP_Error( 'in_lockdown', __( 'Support access is temporarily disabled on this site after repeated failed attempts. Please try again later.', 'trustedlogin' ) );
+			return new \WP_Error( 'in_lockdown', $this->strings->get( Strings::SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON, __( 'Support access is temporarily disabled on this site after repeated failed attempts. Please try again later.', 'trustedlogin' ) ) );
 		}
 
 		// When passed in the endpoint URL, the unique ID will be the raw value, not the hash.
@@ -139,7 +145,7 @@ final class SecurityChecks {
 			$this->logging->log(
 				sprintf(
 					// translators: %s is the error message.
-					__( 'Support access could not be verified — login aborted. (%s)', 'trustedlogin' ),
+					$this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9, __( 'Support access could not be verified — login aborted. (%s)', 'trustedlogin' ) ),
 					$approved->get_error_message()
 				),
 				__METHOD__,

--- a/src/SecurityChecks.php
+++ b/src/SecurityChecks.php
@@ -139,7 +139,7 @@ final class SecurityChecks {
 			$this->logging->log(
 				sprintf(
 					// translators: %s is the error message.
-					Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9, __( 'Support access could not be verified — login aborted. (%s)', 'trustedlogin' ) ),
+					Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35C1B9, __( 'Support access could not be verified — login aborted. (%s)', 'trustedlogin' ) ),
 					$approved->get_error_message()
 				),
 				__METHOD__,

--- a/src/SecurityChecks.php
+++ b/src/SecurityChecks.php
@@ -33,11 +33,6 @@ final class SecurityChecks {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * The transient slug used for storing used accesskeys.
 	 *
 	 * @var string
@@ -96,7 +91,6 @@ final class SecurityChecks {
 
 		$this->logging = $logging;
 		$this->config  = $config;
-		$this->strings = new Strings( $config );
 
 		$this->used_accesskey_transient = 'tl-' . $this->config->ns() . '-used_accesskeys';
 		$this->in_lockdown_transient    = 'tl-' . $this->config->ns() . '-in_lockdown';
@@ -118,7 +112,7 @@ final class SecurityChecks {
 		if ( $this->in_lockdown() ) {
 			$this->logging->log( 'Site is in lockdown mode, aborting login.', __METHOD__, 'error' );
 
-			return new \WP_Error( 'in_lockdown', $this->strings->get( Strings::SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON, __( 'Support access is temporarily disabled on this site after repeated failed attempts. Please try again later.', 'trustedlogin' ) ) );
+			return new \WP_Error( 'in_lockdown', Strings::get( Strings::SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON, __( 'Support access is temporarily disabled on this site after repeated failed attempts. Please try again later.', 'trustedlogin' ) ) );
 		}
 
 		// When passed in the endpoint URL, the unique ID will be the raw value, not the hash.
@@ -145,7 +139,7 @@ final class SecurityChecks {
 			$this->logging->log(
 				sprintf(
 					// translators: %s is the error message.
-					$this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9, __( 'Support access could not be verified — login aborted. (%s)', 'trustedlogin' ) ),
+					Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9, __( 'Support access could not be verified — login aborted. (%s)', 'trustedlogin' ) ),
 					$approved->get_error_message()
 				),
 				__METHOD__,

--- a/src/SiteAccess.php
+++ b/src/SiteAccess.php
@@ -24,6 +24,11 @@ class SiteAccess {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Logging instance.
 	 *
 	 * @var Logging $logging
@@ -48,6 +53,7 @@ class SiteAccess {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config  = $config;
+		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 	}
 
@@ -67,7 +73,7 @@ class SiteAccess {
 		$encryption = new Encryption( $this->config, $remote, $logging );
 
 		if ( ! in_array( $action, self::$sync_actions, true ) ) {
-			return new \WP_Error( 'param_error', __( 'Unexpected action value', 'trustedlogin' ) );
+			return new \WP_Error( 'param_error', $this->strings->get( Strings::UNEXPECTED_ACTION_VALUE, __( 'Unexpected action value', 'trustedlogin' ) ) );
 		}
 
 		$access_key = $this->get_access_key();
@@ -98,7 +104,7 @@ class SiteAccess {
 		}
 
 		if ( empty( $response_json['success'] ) ) {
-			return new \WP_Error( 'sync_error', __( 'Support access could not be registered. Please try again in a minute, or contact the plugin\'s support team.', 'trustedlogin' ) );
+			return new \WP_Error( 'sync_error', $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED, __( 'Support access could not be registered. Please try again in a minute, or contact the plugin\'s support team.', 'trustedlogin' ) ) );
 		}
 
 		// Opportunistically cache the SaaS-supplied webhook URL. This

--- a/src/SiteAccess.php
+++ b/src/SiteAccess.php
@@ -24,11 +24,6 @@ class SiteAccess {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Logging instance.
 	 *
 	 * @var Logging $logging
@@ -53,7 +48,6 @@ class SiteAccess {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config  = $config;
-		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 	}
 
@@ -73,7 +67,7 @@ class SiteAccess {
 		$encryption = new Encryption( $this->config, $remote, $logging );
 
 		if ( ! in_array( $action, self::$sync_actions, true ) ) {
-			return new \WP_Error( 'param_error', $this->strings->get( Strings::UNEXPECTED_ACTION_VALUE, __( 'Unexpected action value', 'trustedlogin' ) ) );
+			return new \WP_Error( 'param_error', Strings::get( Strings::UNEXPECTED_ACTION_VALUE, __( 'Unexpected action value', 'trustedlogin' ) ) );
 		}
 
 		$access_key = $this->get_access_key();
@@ -104,7 +98,7 @@ class SiteAccess {
 		}
 
 		if ( empty( $response_json['success'] ) ) {
-			return new \WP_Error( 'sync_error', $this->strings->get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED, __( 'Support access could not be registered. Please try again in a minute, or contact the plugin\'s support team.', 'trustedlogin' ) ) );
+			return new \WP_Error( 'sync_error', Strings::get( Strings::SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED, __( 'Support access could not be registered. Please try again in a minute, or contact the plugin\'s support team.', 'trustedlogin' ) ) );
 		}
 
 		// Opportunistically cache the SaaS-supplied webhook URL. This

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -176,21 +176,47 @@ class Strings {
 	private static $translations_loaded = false;
 
 	/**
-	 * @var Config
+	 * @var Config|null
 	 */
-	private $config;
+	private static $config;
 
 	/**
 	 * @var array<string, string|callable> Validated overrides keyed by constant value.
 	 */
-	private $overrides;
+	private static $overrides = array();
 
 	/**
-	 * @param Config $config
+	 * Bind the SDK's Strings utility to the active Config.
+	 *
+	 * Must be called once during SDK bootstrap — `Client::__construct()`
+	 * does this. Subsequent `Strings::get()` calls read the integrator's
+	 * override map and the namespace for the runtime filter from the
+	 * Config bound here.
+	 *
+	 * Calling `init()` again replaces the bound Config (useful in tests
+	 * that exercise multiple Configs in sequence; pair with reset()).
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param Config $config Active configuration.
 	 */
-	public function __construct( Config $config ) {
-		$this->config    = $config;
-		$this->overrides = (array) $config->get_setting( 'strings', array() );
+	public static function init( Config $config ) {
+		self::$config    = $config;
+		self::$overrides = (array) $config->get_setting( 'strings', array() );
+	}
+
+	/**
+	 * Test seam: clear all bound state so the next `init()` starts fresh.
+	 *
+	 * Used by PHPUnit tearDown to prevent override leaks between tests.
+	 *
+	 * @since 1.11.0
+	 */
+	public static function reset() {
+		self::$config              = null;
+		self::$overrides           = array();
+		self::$textdomain          = 'trustedlogin';
+		self::$translations_loaded = false;
 	}
 
 	// -----------------------------------------------------------------
@@ -478,8 +504,15 @@ class Strings {
 	 *
 	 * @return string
 	 */
-	public function get( $key, $default, array $context = array() ) {
-		$value = $this->resolve( $key, $default, $context );
+	public static function get( $key, $default, array $context = array() ) {
+		$value = self::resolve( $key, $default, $context );
+
+		// Without an `init()` call the filter has no namespace to attach
+		// to. Return the resolved value without filtering — same English
+		// fallback behavior as if a filter was registered but did nothing.
+		if ( ! self::$config instanceof Config ) {
+			return $value;
+		}
 
 		/**
 		 * Filter the resolved value of a TrustedLogin SDK string.
@@ -495,11 +528,11 @@ class Strings {
 		 * @param Config $config  Active configuration.
 		 */
 		return (string) apply_filters(
-			'trustedlogin/' . $this->config->ns() . '/strings/' . $key,
+			'trustedlogin/' . self::$config->ns() . '/strings/' . $key,
 			$value,
 			$key,
 			$context,
-			$this->config
+			self::$config
 		);
 	}
 
@@ -510,9 +543,9 @@ class Strings {
 	 *
 	 * @return string
 	 */
-	private function resolve( $key, $default, array $context ) {
-		if ( array_key_exists( $key, $this->overrides ) ) {
-			$override = $this->overrides[ $key ];
+	private static function resolve( $key, $default, array $context ) {
+		if ( array_key_exists( $key, self::$overrides ) ) {
+			$override = self::$overrides[ $key ];
 
 			if ( '' === $override ) {
 				return '';

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -531,13 +531,20 @@ class Strings {
 			 * @param array  $context Positional args if any (e.g. count for plurals).
 			 * @param Config $config  Active configuration.
 			 */
-			$value = (string) apply_filters(
-				'trustedlogin/' . self::$config->ns() . '/strings/' . $key,
-				$value,
-				$key,
-				$context,
-				self::$config
-			);
+			try {
+				$value = (string) apply_filters(
+					'trustedlogin/' . self::$config->ns() . '/strings/' . $key,
+					$value,
+					$key,
+					$context,
+					self::$config
+				);
+			} catch ( \Throwable $e ) {
+				// An integrator filter callback that throws should NOT
+				// fatal the SDK. Keep whatever resolve() produced and
+				// log so the integrator can diagnose.
+				self::log_closure_failure( $key, $e );
+			}
 		}
 
 		// Runtime sprintf safety net.
@@ -615,7 +622,20 @@ class Strings {
 			}
 
 			if ( is_callable( $override ) ) {
-				return (string) call_user_func_array( $override, array_values( $context ) );
+				// Catch \Throwable (covers Exception + Error in PHP 7+).
+				// An integrator closure that throws — null pointer,
+				// undefined variable in their callable, DB query
+				// timeout, etc. — would otherwise propagate out of
+				// the SDK as a fatal. Fall back to the SDK default
+				// so the consent screen stays alive.
+				try {
+					return (string) call_user_func_array( $override, array_values( $context ) );
+				} catch ( \Throwable $e ) {
+					// Best-effort log via the active Config's logger.
+					// If logging isn't wired (no init yet, no logging
+					// instance reachable), the SDK silently falls back.
+					self::log_closure_failure( $key, $e );
+				}
 			}
 
 			// Shape mismatch should have been caught by Config::validate_strings().
@@ -626,6 +646,40 @@ class Strings {
 		// against whichever textdomain the integrator routed our `.mo`
 		// files through. When no `.mo` is loaded under that domain,
 		// translate() returns the input verbatim — English fallback.
-		return (string) translate( (string) $default, self::$textdomain );
+		try {
+			return (string) translate( (string) $default, self::$textdomain );
+		} catch ( \Throwable $e ) {
+			// gettext-translations can theoretically throw on a
+			// malformed .mo file; treat as English fallback.
+			self::log_closure_failure( $key, $e );
+			return (string) $default;
+		}
+	}
+
+	/**
+	 * Best-effort log of an integrator-code failure inside Strings
+	 * resolution. Silent fallback if the Logging surface isn't
+	 * reachable — better than letting the exception propagate.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string     $key The Strings constant being resolved.
+	 * @param \Throwable $e   The error.
+	 */
+	private static function log_closure_failure( $key, \Throwable $e ) {
+		if ( ! self::$config instanceof Config ) {
+			return;
+		}
+		// Use error_log() as the minimal sink. The SDK's Logging class
+		// has heavier deps; resolve() is too hot a path to construct
+		// one. The integrator can hook 'gettext'/php error-log to
+		// route as needed.
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( sprintf(
+				'[TrustedLogin] Strings::%s resolution failed: %s',
+				$key,
+				$e->getMessage()
+			) );
+		}
 	}
 }

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -62,6 +62,7 @@ class Strings {
 	const BY_GRANTING_ACCESS_YOU_AGREE_TO = 'by_granting_access_you_agree_to';
 	const REFERENCE_S = 'reference_s';
 	const VENDOR_HAS_SITE_ACCESS_THAT = '1_s_has_site_access_that';
+	const VISIT_VENDOR_WEBSITE         = 'visit_vendor_website';
 	const VENDOR_WOULD_LIKE_SUPPORT_ACCESS = '1_s_would_like_support_access';
 	const GRANT_1_S_ACCESS_TO_THIS = 'grant_1_s_access_to_this';
 	const INCLUDE_A_MESSAGE_FOR_SUPPORT = 'include_a_message_for_support';
@@ -94,7 +95,7 @@ class Strings {
 	const DEBUGGING_INFO = 'debugging_info';
 	const TRUSTEDLOGIN_CONFIG = 'trustedlogin_config';
 	const GRANT_S_ACCESS = 'grant_s_access';
-	const EXTEND_S_ACCESS = 'extend_s_access';
+	const EXTEND_VENDOR_ACCESS_FOR_DURATION = 'extend_vendor_access_for_duration';
 	const COULD_NOT_CREATE_SUPPORT_ACCESS = 'could_not_create_support_access';
 	const THE_USER_DETAILS_COULD_NOT_BE = 'the_user_details_could_not_be';
 	const PLEASE_A_HREF_1_S_TARGET = 'please_a_href_1_s_target';
@@ -257,6 +258,7 @@ class Strings {
 			self::BY_GRANTING_ACCESS_YOU_AGREE_TO => array( 'placeholders' => 0 ), // By granting access, you agree to the {{tos_link}}.
 			self::REFERENCE_S => array( 'placeholders' => 1 ), // Reference #%s
 			self::VENDOR_HAS_SITE_ACCESS_THAT => array( 'placeholders' => 2 ), // %1$s has site access that expires in %2$s.
+			self::VISIT_VENDOR_WEBSITE        => array( 'placeholders' => 1 ), // Visit the %s website (opens in a new tab)
 			self::VENDOR_WOULD_LIKE_SUPPORT_ACCESS => array( 'placeholders' => 1 ), // %1$s would like support access to this site.
 			self::GRANT_1_S_ACCESS_TO_THIS => array( 'placeholders' => 1 ), // Grant %1$s access to this site.
 			self::INCLUDE_A_MESSAGE_FOR_SUPPORT => array( 'placeholders' => 0 ), // Include a message for support?
@@ -289,7 +291,7 @@ class Strings {
 			self::DEBUGGING_INFO => array( 'placeholders' => 0 ), // Debugging Info
 			self::TRUSTEDLOGIN_CONFIG => array( 'placeholders' => 0 ), // TrustedLogin Config
 			self::GRANT_S_ACCESS => array( 'placeholders' => 1 ), // Grant %s Access
-			self::EXTEND_S_ACCESS => array( 'placeholders' => 1 ), // Extend %s Access
+			self::EXTEND_VENDOR_ACCESS_FOR_DURATION => array( 'placeholders' => 2 ), // Extend %1$s Access for %2$s
 			self::COULD_NOT_CREATE_SUPPORT_ACCESS => array( 'placeholders' => 0 ), // Could not create support access.
 			self::THE_USER_DETAILS_COULD_NOT_BE => array( 'placeholders' => 1 ), // The user details could not be sent to %1$s automatically.
 			self::PLEASE_A_HREF_1_S_TARGET => array( 'placeholders' => 2 ), // Please <a href="%1$s" target="_blank">click here</a> to go t
@@ -423,12 +425,17 @@ class Strings {
 		}
 
 		if ( ! self::$translations_loaded ) {
+			// Read self::$textdomain at fire time (not captured by
+			// value). If load_translations() is called again with a
+			// different domain BEFORE this hook fires, the second
+			// call's textdomain wins for the reload — matching the
+			// most recent `self::$textdomain` write at line 418.
 			add_action(
 				'change_locale',
-				static function ( $new_locale ) use ( $textdomain ) {
+				static function ( $new_locale ) {
 					$mo = self::mo_path_for( $new_locale );
 					if ( $mo && is_readable( $mo ) ) {
-						load_textdomain( $textdomain, $mo );
+						load_textdomain( self::$textdomain, $mo );
 					}
 				}
 			);

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -31,135 +31,138 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Translatable strings registry, runtime override resolver, and integrator
+ * translation router.
+ *
  * @since 1.11.0
  */
 class Strings {
 
 	// -----------------------------------------------------------------
-	//  Public contract: every overrideable string gets a constant here.
-	//  Constants are stable across versions (renames are breaking).
+	// Public contract: every overrideable string gets a constant here.
+	// Constants are stable across versions (renames are breaking).
 	// -----------------------------------------------------------------
 
-	const REVOKE_ACCESS = 'revoke_access';
-	const YOU_ARE_LOGGED_IN_AS_A = 'you_are_logged_in_as_a';
-	const GRANT_SUPPORT_ACCESS = 'grant_support_access';
+	const REVOKE_ACCESS                           = 'revoke_access';
+	const YOU_ARE_LOGGED_IN_AS_A                  = 'you_are_logged_in_as_a';
+	const GRANT_SUPPORT_ACCESS                    = 'grant_support_access';
 	const VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE = 'verification_issue_request_could_not_be';
-	const YOU_DO_NOT_HAVE_THE_ABILITY = 'you_do_not_have_the_ability';
-	const SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS = 'support_access_requires_a_secure_https';
-	const THE_SUPPORT_USER_WAS_NOT_DELETED = 'the_support_user_was_not_deleted';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET = 'support_access_could_not_be_set';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET_799354 = 'support_access_could_not_be_set_799354';
-	const SUPPORT_LOGIN_COULD_NOT_COMPLETE = 'support_login_could_not_complete';
-	const RETURN_TO_YOUR_SUPPORT_TOOL_TO = 'return_to_your_support_tool_to';
-	const UNKNOWN_USER_D = 'unknown_user_d';
-	const CREATED_1_S_AGO_BY_2 = 'created_1_s_ago_by_2';
-	const CONTACT_S_SUPPORT = 'contact_s_support';
-	const EMAIL_S = 'email_s';
+	const YOU_DO_NOT_HAVE_THE_ABILITY             = 'you_do_not_have_the_ability';
+	const SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS  = 'support_access_requires_a_secure_https';
+	const THE_SUPPORT_USER_WAS_NOT_DELETED        = 'the_support_user_was_not_deleted';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET         = 'support_access_could_not_be_set';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_799354  = 'support_access_could_not_be_set_799354';
+	const SUPPORT_LOGIN_COULD_NOT_COMPLETE        = 'support_login_could_not_complete';
+	const RETURN_TO_YOUR_SUPPORT_TOOL_TO          = 'return_to_your_support_tool_to';
+	const UNKNOWN_USER_D                          = 'unknown_user_d';
+	const CREATED_1_S_AGO_BY_2                    = 'created_1_s_ago_by_2';
+	const CONTACT_S_SUPPORT                       = 'contact_s_support';
+	const EMAIL_S                                 = 'email_s';
 	const SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE = 'support_access_is_temporarily_unavailable_please';
-	const TRY_RECONNECTING = 'try_reconnecting';
-	const SECURED_BY_TRUSTEDLOGIN = 'secured_by_trustedlogin';
-	const TERMS_OF_SERVICE = 'terms_of_service';
-	const BY_GRANTING_ACCESS_YOU_AGREE_TO = 'by_granting_access_you_agree_to';
-	const REFERENCE_S = 'reference_s';
-	const VENDOR_HAS_SITE_ACCESS_THAT = '1_s_has_site_access_that';
-	const VISIT_VENDOR_WEBSITE         = 'visit_vendor_website';
-	const VENDOR_WOULD_LIKE_SUPPORT_ACCESS = '1_s_would_like_support_access';
-	const GRANT_1_S_ACCESS_TO_THIS = 'grant_1_s_access_to_this';
-	const INCLUDE_A_MESSAGE_FOR_SUPPORT = 'include_a_message_for_support';
-	const PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE = 'please_describe_the_issue_you_are';
-	const ACCESS_THIS_SITE_FOR_S = 'access_this_site_for_s';
-	const ACCESS_AUTO_EXPIRES_IN_S_YOU = 'access_auto_expires_in_s_you';
-	const CREATE_A_USER_WITH_A_ROLE = 'create_a_user_with_a_role';
-	const VIEW_MODIFIED_ROLE_CAPABILITIES = 'view_modified_role_capabilities';
-	const CREATE_A_USER_WITH_A_ROLE_60602c = 'create_a_user_with_a_role_60602c';
-	const INCLUDE_THE_LINK_SITE_HEALTH_LINK = 'include_the_link_site_health_link';
-	const ADDITIONAL_CAPABILITIES = 'additional_capabilities';
-	const REMOVED_CAPABILITIES = 'removed_capabilities';
-	const S_SUPPORT_MAY_NOT_BE_ABLE = 's_support_may_not_be_able';
-	const THIS_WEBSITE_IS_RUNNING_IN_A = 'this_website_is_running_in_a';
-	const LEARN_MORE = 'learn_more';
-	const LEARN_ABOUT_TRUSTEDLOGIN = 'learn_about_trustedlogin';
-	const TRUSTEDLOGIN_STATUS = 'trustedlogin_status';
-	const OFFLINE = 'offline';
-	const ONLINE = 'online';
-	const API_KEY = 'api_key';
-	const LICENSE_KEY = 'license_key';
-	const LOG_URL = 'log_url';
-	const LOG_PATH_IS_OUTSIDE_ABSPATH_NOT = 'log_path_is_outside_abspath_not';
-	const DOWNLOAD_THE_LOG = 'download_the_log';
-	const LOG_LEVEL = 'log_level';
-	const DEFAULT = 'default';
-	const WEBHOOK_URL = 'webhook_url';
-	const VENDOR_PUBLIC_KEY = 'vendor_public_key';
-	const VERIFY_KEY = 'verify_key';
-	const DEBUGGING_INFO = 'debugging_info';
-	const TRUSTEDLOGIN_CONFIG = 'trustedlogin_config';
-	const GRANT_S_ACCESS = 'grant_s_access';
+	const TRY_RECONNECTING                                 = 'try_reconnecting';
+	const SECURED_BY_TRUSTEDLOGIN                          = 'secured_by_trustedlogin';
+	const TERMS_OF_SERVICE                                 = 'terms_of_service';
+	const BY_GRANTING_ACCESS_YOU_AGREE_TO                  = 'by_granting_access_you_agree_to';
+	const REFERENCE_S                                      = 'reference_s';
+	const VENDOR_HAS_SITE_ACCESS_THAT                      = '1_s_has_site_access_that';
+	const VISIT_VENDOR_WEBSITE                             = 'visit_vendor_website';
+	const VENDOR_WOULD_LIKE_SUPPORT_ACCESS                 = '1_s_would_like_support_access';
+	const GRANT_1_S_ACCESS_TO_THIS                         = 'grant_1_s_access_to_this';
+	const INCLUDE_A_MESSAGE_FOR_SUPPORT                    = 'include_a_message_for_support';
+	const PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE                = 'please_describe_the_issue_you_are';
+	const ACCESS_THIS_SITE_FOR_S                           = 'access_this_site_for_s';
+	const ACCESS_AUTO_EXPIRES_IN_S_YOU                     = 'access_auto_expires_in_s_you';
+	const CREATE_A_USER_WITH_A_ROLE                        = 'create_a_user_with_a_role';
+	const VIEW_MODIFIED_ROLE_CAPABILITIES                  = 'view_modified_role_capabilities';
+	const CREATE_A_USER_WITH_A_ROLE_60602C                 = 'create_a_user_with_a_role_60602C';
+	const INCLUDE_THE_LINK_SITE_HEALTH_LINK                = 'include_the_link_site_health_link';
+	const ADDITIONAL_CAPABILITIES                          = 'additional_capabilities';
+	const REMOVED_CAPABILITIES                             = 'removed_capabilities';
+	const S_SUPPORT_MAY_NOT_BE_ABLE                        = 's_support_may_not_be_able';
+	const THIS_WEBSITE_IS_RUNNING_IN_A                     = 'this_website_is_running_in_a';
+	const LEARN_MORE                                       = 'learn_more';
+	const LEARN_ABOUT_TRUSTEDLOGIN                         = 'learn_about_trustedlogin';
+	const TRUSTEDLOGIN_STATUS                              = 'trustedlogin_status';
+	const OFFLINE                           = 'offline';
+	const ONLINE                            = 'online';
+	const API_KEY                           = 'api_key';
+	const LICENSE_KEY                       = 'license_key';
+	const LOG_URL                           = 'log_url';
+	const LOG_PATH_IS_OUTSIDE_ABSPATH_NOT   = 'log_path_is_outside_abspath_not';
+	const DOWNLOAD_THE_LOG                  = 'download_the_log';
+	const LOG_LEVEL                         = 'log_level';
+	const DEFAULT_LEVEL                     = 'default';
+	const WEBHOOK_URL                       = 'webhook_url';
+	const VENDOR_PUBLIC_KEY                 = 'vendor_public_key';
+	const VERIFY_KEY                        = 'verify_key';
+	const DEBUGGING_INFO                    = 'debugging_info';
+	const TRUSTEDLOGIN_CONFIG               = 'trustedlogin_config';
+	const GRANT_S_ACCESS                    = 'grant_s_access';
 	const EXTEND_VENDOR_ACCESS_FOR_DURATION = 'extend_vendor_access_for_duration';
-	const COULD_NOT_CREATE_SUPPORT_ACCESS = 'could_not_create_support_access';
-	const THE_USER_DETAILS_COULD_NOT_BE = 'the_user_details_could_not_be';
-	const PLEASE_A_HREF_1_S_TARGET = 'please_a_href_1_s_target';
-	const CONFIRM = 'confirm';
-	const OK = 'ok';
-	const GO_TO_1_S_SUPPORT_SITE = 'go_to_1_s_support_site';
-	const CLOSE = 'close';
-	const CANCEL = 'cancel';
-	const REVOKE_1_S_SUPPORT_ACCESS = 'revoke_1_s_support_access';
-	const COPY = 'copy';
-	const COPIED = 'copied';
-	const THIS_LINK_OPENS_IN_A_NEW = 'this_link_opens_in_a_new';
-	const THE_ACCESS_KEY_HAS_BEEN_COPIED = 'the_access_key_has_been_copied';
-	const SUPPORT_ACCESS_GRANTED = 'support_access_granted';
+	const COULD_NOT_CREATE_SUPPORT_ACCESS   = 'could_not_create_support_access';
+	const THE_USER_DETAILS_COULD_NOT_BE     = 'the_user_details_could_not_be';
+	const PLEASE_A_HREF_1_S_TARGET          = 'please_a_href_1_s_target';
+	const CONFIRM                           = 'confirm';
+	const OK                                = 'ok';
+	const GO_TO_1_S_SUPPORT_SITE            = 'go_to_1_s_support_site';
+	const CLOSE                             = 'close';
+	const CANCEL                            = 'cancel';
+	const REVOKE_1_S_SUPPORT_ACCESS         = 'revoke_1_s_support_access';
+	const COPY                              = 'copy';
+	const COPIED                            = 'copied';
+	const THIS_LINK_OPENS_IN_A_NEW          = 'this_link_opens_in_a_new';
+	const THE_ACCESS_KEY_HAS_BEEN_COPIED    = 'the_access_key_has_been_copied';
+	const SUPPORT_ACCESS_GRANTED            = 'support_access_granted';
 	const A_TEMPORARY_SUPPORT_USER_HAS_BEEN = 'a_temporary_support_user_has_been';
 	const GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR = 'generating_encrypting_secure_support_access_for';
-	const EXTENDING_SUPPORT_ACCESS_FOR_1_S = 'extending_support_access_for_1_s';
-	const SENDING_ENCRYPTED_ACCESS_TO_1_S = 'sending_encrypted_access_to_1_s';
-	const COULDN_T_REGISTER_SUPPORT_ACCESS_WITH = 'couldn_t_register_support_access_with';
-	const ACTION_CANCELLED = 'action_cancelled';
-	const A_SUPPORT_ACCOUNT_FOR_1_S = 'a_support_account_for_1_s';
-	const SUPPORT_ACCESS_WAS_NOT_GRANTED = 'support_access_was_not_granted';
-	const THERE_WAS_AN_ERROR_GRANTING_ACCESS = 'there_was_an_error_granting_access';
-	const YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE = 'your_authorized_session_has_expired_please';
-	const THE_REQUEST_TOOK_TOO_LONG_TO = 'the_request_took_too_long_to';
-	const SUPPORT_ACCESS_KEY_CREATED = 'support_access_key_created';
-	const SHARE_THIS_ACCESS_KEY_WITH_1 = 'share_this_access_key_with_1';
-	const THE_SUPPORT_TEAM_S_SITE_COULD = 'the_support_team_s_site_could';
-	const VENDOR_SUPPORT_USER_ALREADY_EXISTS = '1_s_support_user_already_exists';
-	const A_SUPPORT_USER_FOR_1_S = 'a_support_user_for_1_s';
-	const NO_S_USERS_EXIST = 'no_s_users_exist';
-	const ERROR = 'error';
-	const THERE_WAS_AN_ERROR_RETURNING_THE = 'there_was_an_error_returning_the';
-	const SITE_ACCESS_KEY = 'site_access_key';
-	const ACCESS_KEY = 'access_key';
-	const COPY_THE_ACCESS_KEY_TO_YOUR = 'copy_the_access_key_to_your';
-	const THE_ACCESS_KEY_IS_NOT_A = 'the_access_key_is_not_a';
-	const YOU_ARE_LOGGED_IN_AS_A_4eed50 = 'you_are_logged_in_as_a_4eed50';
-	const ACCESS_EXPIRES_IN_S = 'access_expires_in_s';
-	const YOU_WERE_ALREADY_SIGNED_IN_AS = 'you_were_already_signed_in_as';
-	const S_ACCESS_REVOKED = 's_access_revoked';
-	const YOU_MAY_SAFELY_CLOSE_THIS_WINDOW = 'you_may_safely_close_this_window';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET_979c0f = 'support_access_could_not_be_set_979c0f';
-	const SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED = 'support_access_could_not_be_verified';
-	const THE_SUPPORT_TEAM_S_ACCOUNT_HAS = 'the_support_team_s_account_has';
-	const SUPPORT_ACCESS_WAS_REFUSED_PLEASE_CONTACT = 'support_access_was_refused_please_contact';
-	const THE_SUPPORT_TEAM_S_SITE_IS = 'the_support_team_s_site_is';
-	const THE_SUPPORT_TEAM_S_SITE_IS_6d0ab1 = 'the_support_team_s_site_is_6d0ab1';
-	const THE_SUPPORT_TEAM_S_SITE_RETURNED = 'the_support_team_s_site_returned';
-	const COULD_NOT_REACH_THE_SUPPORT_TEAM = 'could_not_reach_the_support_team';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET_084a44 = 'support_access_could_not_be_set_084a44';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET_829416 = 'support_access_could_not_be_set_829416';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET_be0b5d = 'support_access_could_not_be_set_be0b5d';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET_343150 = 'support_access_could_not_be_set_343150';
-	const SUPPORT_ACCESS_COULD_NOT_BE_SET_c6bda2 = 'support_access_could_not_be_set_c6bda2';
-	const SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING    = 'support_access_vendor_returned_nothing';
-	const SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED      = 'support_access_vendor_not_configured';
-	const SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE = 'support_access_vendor_response_incomplete';
-	const SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON = 'support_access_is_temporarily_disabled_on';
-	const SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9 = 'support_access_could_not_be_verified_35c1b9';
-	const UNEXPECTED_ACTION_VALUE = 'unexpected_action_value';
-	const SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED = 'support_access_could_not_be_registered';
-	const S_SUPPORT = 's_support';
-	const USER_NOT_CREATED_USER_WITH_THAT = 'user_not_created_user_with_that';
+	const EXTENDING_SUPPORT_ACCESS_FOR_1_S                = 'extending_support_access_for_1_s';
+	const SENDING_ENCRYPTED_ACCESS_TO_1_S                 = 'sending_encrypted_access_to_1_s';
+	const COULDN_T_REGISTER_SUPPORT_ACCESS_WITH           = 'couldn_t_register_support_access_with';
+	const ACTION_CANCELLED                                = 'action_cancelled';
+	const A_SUPPORT_ACCOUNT_FOR_1_S                       = 'a_support_account_for_1_s';
+	const SUPPORT_ACCESS_WAS_NOT_GRANTED                  = 'support_access_was_not_granted';
+	const THERE_WAS_AN_ERROR_GRANTING_ACCESS              = 'there_was_an_error_granting_access';
+	const YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE      = 'your_authorized_session_has_expired_please';
+	const THE_REQUEST_TOOK_TOO_LONG_TO                    = 'the_request_took_too_long_to';
+	const SUPPORT_ACCESS_KEY_CREATED                      = 'support_access_key_created';
+	const SHARE_THIS_ACCESS_KEY_WITH_1                    = 'share_this_access_key_with_1';
+	const THE_SUPPORT_TEAM_S_SITE_COULD                   = 'the_support_team_s_site_could';
+	const VENDOR_SUPPORT_USER_ALREADY_EXISTS              = '1_s_support_user_already_exists';
+	const A_SUPPORT_USER_FOR_1_S                          = 'a_support_user_for_1_s';
+	const NO_S_USERS_EXIST                                = 'no_s_users_exist';
+	const ERROR                                       = 'error';
+	const THERE_WAS_AN_ERROR_RETURNING_THE            = 'there_was_an_error_returning_the';
+	const SITE_ACCESS_KEY                             = 'site_access_key';
+	const ACCESS_KEY                                  = 'access_key';
+	const COPY_THE_ACCESS_KEY_TO_YOUR                 = 'copy_the_access_key_to_your';
+	const THE_ACCESS_KEY_IS_NOT_A                     = 'the_access_key_is_not_a';
+	const YOU_ARE_LOGGED_IN_AS_A_4EED50               = 'you_are_logged_in_as_a_4EED50';
+	const ACCESS_EXPIRES_IN_S                         = 'access_expires_in_s';
+	const YOU_WERE_ALREADY_SIGNED_IN_AS               = 'you_were_already_signed_in_as';
+	const S_ACCESS_REVOKED                            = 's_access_revoked';
+	const YOU_MAY_SAFELY_CLOSE_THIS_WINDOW            = 'you_may_safely_close_this_window';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_979C0F      = 'support_access_could_not_be_set_979C0F';
+	const SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED        = 'support_access_could_not_be_verified';
+	const THE_SUPPORT_TEAM_S_ACCOUNT_HAS              = 'the_support_team_s_account_has';
+	const SUPPORT_ACCESS_WAS_REFUSED_PLEASE_CONTACT   = 'support_access_was_refused_please_contact';
+	const THE_SUPPORT_TEAM_S_SITE_IS                  = 'the_support_team_s_site_is';
+	const THE_SUPPORT_TEAM_S_SITE_IS_6D0AB1           = 'the_support_team_s_site_is_6D0AB1';
+	const THE_SUPPORT_TEAM_S_SITE_RETURNED            = 'the_support_team_s_site_returned';
+	const COULD_NOT_REACH_THE_SUPPORT_TEAM            = 'could_not_reach_the_support_team';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_084A44      = 'support_access_could_not_be_set_084A44';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_829416      = 'support_access_could_not_be_set_829416';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_BE0B5D      = 'support_access_could_not_be_set_BE0B5D';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_343150      = 'support_access_could_not_be_set_343150';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_C6BDA2      = 'support_access_could_not_be_set_C6BDA2';
+	const SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING      = 'support_access_vendor_returned_nothing';
+	const SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED        = 'support_access_vendor_not_configured';
+	const SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE   = 'support_access_vendor_response_incomplete';
+	const SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON   = 'support_access_is_temporarily_disabled_on';
+	const SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35C1B9 = 'support_access_could_not_be_verified_35C1B9';
+	const UNEXPECTED_ACTION_VALUE                     = 'unexpected_action_value';
+	const SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED      = 'support_access_could_not_be_registered';
+	const S_SUPPORT                                   = 's_support';
+	const USER_NOT_CREATED_USER_WITH_THAT             = 'user_not_created_user_with_that';
 
 	/**
 	 * Textdomain that runtime translation lookups should hit. Set by
@@ -172,17 +175,30 @@ class Strings {
 	private static $textdomain = 'trustedlogin';
 
 	/**
-	 * @var bool Has the integrator opted in to loading bundled translations?
+	 * Whether the integrator opted in to loading bundled translations.
+	 *
+	 * @var bool
 	 */
 	private static $translations_loaded = false;
 
 	/**
+	 * Textdomain queued by a pre-init `load_translations()` call.
+	 *
+	 * @var string
+	 */
+	private static $pending_textdomain = '';
+
+	/**
+	 * Active configuration bound by `init()`.
+	 *
 	 * @var Config|null
 	 */
 	private static $config;
 
 	/**
-	 * @var array<string, string|callable> Validated overrides keyed by constant value.
+	 * Validated overrides keyed by constant value.
+	 *
+	 * @var array<string, string|callable>
 	 */
 	private static $overrides = array();
 
@@ -192,7 +208,7 @@ class Strings {
 	 *
 	 * @since 1.11.0
 	 *
-	 * @param Config $config
+	 * @param Config $config Active configuration to bind for overrides + filter namespacing.
 	 */
 	public static function init( Config $config ) {
 		self::$config    = $config;
@@ -209,139 +225,172 @@ class Strings {
 		self::$overrides           = array();
 		self::$textdomain          = 'trustedlogin';
 		self::$translations_loaded = false;
+		self::$pending_textdomain  = '';
+	}
+
+	/**
+	 * `init` action callback for textdomains queued by a pre-init
+	 * `load_translations()`.
+	 *
+	 * @since 1.11.0
+	 */
+	public static function on_init_load_translations() {
+		if ( '' === self::$pending_textdomain ) {
+			return;
+		}
+		$pending                  = self::$pending_textdomain;
+		self::$pending_textdomain = '';
+		self::load_translations( $pending );
+	}
+
+	/**
+	 * `change_locale` action callback. Reloads the SDK's `.mo` for the
+	 * new locale against the currently bound integrator textdomain.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $new_locale Locale that WordPress just switched to.
+	 */
+	public static function on_change_locale( $new_locale ) {
+		$mo = self::mo_path_for( $new_locale );
+		if ( $mo && is_readable( $mo ) ) {
+			load_textdomain( self::$textdomain, $mo );
+		}
 	}
 
 
 	/**
-	 * @return array<string, array{placeholders:int}>
+	 * Registry of every overrideable key and its placeholder budget.
 	 *
 	 * `placeholders`: how many positional sprintf args the default
 	 * requires. 0 = no placeholders, override is taken verbatim.
 	 * 1+ = override MUST resolve to the same number of placeholders
 	 * (validated behaviorally — see {@see Config::placeholders_safe()}).
+	 *
+	 * @return array<string, array{placeholders:int}>
 	 */
 	public static function registry() {
 		return array(
-			self::REVOKE_ACCESS => array( 'placeholders' => 0 ), // Revoke Access
-			self::YOU_ARE_LOGGED_IN_AS_A => array( 'placeholders' => 0 ), // You are logged in as a support user. Click to permanently re
-			self::GRANT_SUPPORT_ACCESS => array( 'placeholders' => 0 ), // Grant Support Access
-			self::VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE => array( 'placeholders' => 0 ), // Verification issue: Request could not be verified. Please re
-			self::YOU_DO_NOT_HAVE_THE_ABILITY => array( 'placeholders' => 0 ), // You do not have the ability to create users.
-			self::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS => array( 'placeholders' => 0 ), // Support access requires a secure (HTTPS) connection. Please 
-			self::THE_SUPPORT_USER_WAS_NOT_DELETED => array( 'placeholders' => 0 ), // The support user was not deleted.
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_799354 => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
-			self::SUPPORT_LOGIN_COULD_NOT_COMPLETE => array( 'placeholders' => 0 ), // Support login could not complete
-			self::RETURN_TO_YOUR_SUPPORT_TOOL_TO => array( 'placeholders' => 0 ), // Return to your support tool to try again.
-			self::UNKNOWN_USER_D => array( 'placeholders' => 1 ), // Unknown (User #%d)
-			self::CREATED_1_S_AGO_BY_2 => array( 'placeholders' => 2 ), // Created %1$s ago by %2$s
-			self::CONTACT_S_SUPPORT => array( 'placeholders' => 1 ), // Contact %s support
-			self::EMAIL_S => array( 'placeholders' => 1 ), // Email %s
-			self::SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE => array( 'placeholders' => 0 ), // Support access is temporarily unavailable. Please try again 
-			self::TRY_RECONNECTING => array( 'placeholders' => 0 ), // Try reconnecting
-			self::SECURED_BY_TRUSTEDLOGIN => array( 'placeholders' => 0 ), // Secured by TrustedLogin
-			self::TERMS_OF_SERVICE => array( 'placeholders' => 0 ), // Terms of Service
-			self::BY_GRANTING_ACCESS_YOU_AGREE_TO => array( 'placeholders' => 0 ), // By granting access, you agree to the {{tos_link}}.
-			self::REFERENCE_S => array( 'placeholders' => 1 ), // Reference #%s
-			self::VENDOR_HAS_SITE_ACCESS_THAT => array( 'placeholders' => 2 ), // %1$s has site access that expires in %2$s.
-			self::VISIT_VENDOR_WEBSITE        => array( 'placeholders' => 1 ), // Visit the %s website (opens in a new tab)
-			self::VENDOR_WOULD_LIKE_SUPPORT_ACCESS => array( 'placeholders' => 1 ), // %1$s would like support access to this site.
-			self::GRANT_1_S_ACCESS_TO_THIS => array( 'placeholders' => 1 ), // Grant %1$s access to this site.
-			self::INCLUDE_A_MESSAGE_FOR_SUPPORT => array( 'placeholders' => 0 ), // Include a message for support?
-			self::PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE => array( 'placeholders' => 0 ), // Please describe the issue you are having.
-			self::ACCESS_THIS_SITE_FOR_S => array( 'placeholders' => 1 ), // Access this site for %s.
-			self::ACCESS_AUTO_EXPIRES_IN_S_YOU => array( 'placeholders' => 1 ), // Access auto-expires in %s. You may revoke access at any time
-			self::CREATE_A_USER_WITH_A_ROLE => array( 'placeholders' => 1 ), // Create a user with a role based on %s.
-			self::VIEW_MODIFIED_ROLE_CAPABILITIES => array( 'placeholders' => 0 ), // View modified role capabilities
-			self::CREATE_A_USER_WITH_A_ROLE_60602c => array( 'placeholders' => 1 ), // Create a user with a role of %s.
-			self::INCLUDE_THE_LINK_SITE_HEALTH_LINK => array( 'placeholders' => 0 ), // Include the [link]Site Health[/link] troubleshooting report
-			self::ADDITIONAL_CAPABILITIES => array( 'placeholders' => 0 ), // Additional capabilities:
-			self::REMOVED_CAPABILITIES => array( 'placeholders' => 0 ), // Removed capabilities:
-			self::S_SUPPORT_MAY_NOT_BE_ABLE => array( 'placeholders' => 1 ), // %s support may not be able to access this site.
-			self::THIS_WEBSITE_IS_RUNNING_IN_A => array( 'placeholders' => 0 ), // This website is running in a local development environment. 
-			self::LEARN_MORE => array( 'placeholders' => 0 ), // Learn more.
-			self::LEARN_ABOUT_TRUSTEDLOGIN => array( 'placeholders' => 0 ), // Learn about TrustedLogin
-			self::TRUSTEDLOGIN_STATUS => array( 'placeholders' => 0 ), // TrustedLogin Status
-			self::OFFLINE => array( 'placeholders' => 0 ), // Offline
-			self::ONLINE => array( 'placeholders' => 0 ), // Online
-			self::API_KEY => array( 'placeholders' => 0 ), // API Key
-			self::LICENSE_KEY => array( 'placeholders' => 0 ), // License Key
-			self::LOG_URL => array( 'placeholders' => 0 ), // Log URL
-			self::LOG_PATH_IS_OUTSIDE_ABSPATH_NOT => array( 'placeholders' => 0 ), // (Log path is outside ABSPATH; not exposing as URL.)
-			self::DOWNLOAD_THE_LOG => array( 'placeholders' => 0 ), // Download the log
-			self::LOG_LEVEL => array( 'placeholders' => 0 ), // Log Level
-			self::DEFAULT => array( 'placeholders' => 0 ), // (Default)
-			self::WEBHOOK_URL => array( 'placeholders' => 0 ), // Webhook URL
-			self::VENDOR_PUBLIC_KEY => array( 'placeholders' => 0 ), // Vendor Public Key
-			self::VERIFY_KEY => array( 'placeholders' => 0 ), // Verify key
-			self::DEBUGGING_INFO => array( 'placeholders' => 0 ), // Debugging Info
-			self::TRUSTEDLOGIN_CONFIG => array( 'placeholders' => 0 ), // TrustedLogin Config
-			self::GRANT_S_ACCESS => array( 'placeholders' => 1 ), // Grant %s Access
-			self::EXTEND_VENDOR_ACCESS_FOR_DURATION => array( 'placeholders' => 2 ), // Extend %1$s Access for %2$s
-			self::COULD_NOT_CREATE_SUPPORT_ACCESS => array( 'placeholders' => 0 ), // Could not create support access.
-			self::THE_USER_DETAILS_COULD_NOT_BE => array( 'placeholders' => 1 ), // The user details could not be sent to %1$s automatically.
-			self::PLEASE_A_HREF_1_S_TARGET => array( 'placeholders' => 2 ), // Please <a href="%1$s" target="_blank">click here</a> to go t
-			self::CONFIRM => array( 'placeholders' => 0 ), // Confirm
-			self::OK => array( 'placeholders' => 0 ), // Ok
-			self::GO_TO_1_S_SUPPORT_SITE => array( 'placeholders' => 1 ), // Go to %1$s support site
-			self::CLOSE => array( 'placeholders' => 0 ), // Close
-			self::CANCEL => array( 'placeholders' => 0 ), // Cancel
-			self::REVOKE_1_S_SUPPORT_ACCESS => array( 'placeholders' => 1 ), // Revoke %1$s support access
-			self::COPY => array( 'placeholders' => 0 ), // Copy
-			self::COPIED => array( 'placeholders' => 0 ), // Copied!
-			self::THIS_LINK_OPENS_IN_A_NEW => array( 'placeholders' => 0 ), // (This link opens in a new window.)
-			self::THE_ACCESS_KEY_HAS_BEEN_COPIED => array( 'placeholders' => 0 ), // The access key has been copied to your clipboard.
-			self::SUPPORT_ACCESS_GRANTED => array( 'placeholders' => 0 ), // Support access granted
-			self::A_TEMPORARY_SUPPORT_USER_HAS_BEEN => array( 'placeholders' => 1 ), // A temporary support user has been created, and sent to %1$s 
-			self::GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR => array( 'placeholders' => 1 ), // Generating & encrypting secure support access for %1$s
-			self::EXTENDING_SUPPORT_ACCESS_FOR_1_S => array( 'placeholders' => 2 ), // Extending support access for %1$s by %2$s
-			self::SENDING_ENCRYPTED_ACCESS_TO_1_S => array( 'placeholders' => 1 ), // Sending encrypted access to %1$s.
-			self::COULDN_T_REGISTER_SUPPORT_ACCESS_WITH => array( 'placeholders' => 1 ), // Couldn't register support access with %1$s
-			self::ACTION_CANCELLED => array( 'placeholders' => 0 ), // Action Cancelled
-			self::A_SUPPORT_ACCOUNT_FOR_1_S => array( 'placeholders' => 1 ), // A support account for %1$s was not created.
-			self::SUPPORT_ACCESS_WAS_NOT_GRANTED => array( 'placeholders' => 0 ), // Support Access Was Not Granted
-			self::THERE_WAS_AN_ERROR_GRANTING_ACCESS => array( 'placeholders' => 0 ), // There was an error granting access: 
-			self::YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE => array( 'placeholders' => 0 ), // Your authorized session has expired. Please refresh the page
-			self::THE_REQUEST_TOOK_TOO_LONG_TO => array( 'placeholders' => 0 ), // The request took too long to complete. Please try again.
-			self::SUPPORT_ACCESS_KEY_CREATED => array( 'placeholders' => 0 ), // Support Access Key Created
-			self::SHARE_THIS_ACCESS_KEY_WITH_1 => array( 'placeholders' => 1 ), // Share this access key with %1$s to give them secure access:
-			self::THE_SUPPORT_TEAM_S_SITE_COULD => array( 'placeholders' => 0 ), // The support team's site could not be found.
-			self::VENDOR_SUPPORT_USER_ALREADY_EXISTS => array( 'placeholders' => 1 ), // %1$s Support user already exists
-			self::A_SUPPORT_USER_FOR_1_S => array( 'placeholders' => 2 ), // A support user for %1$s already exists. You may revoke this 
-			self::NO_S_USERS_EXIST => array( 'placeholders' => 1 ), // No %s users exist.
-			self::ERROR => array( 'placeholders' => 0 ), // Error
-			self::THERE_WAS_AN_ERROR_RETURNING_THE => array( 'placeholders' => 0 ), // There was an error returning the access key.
-			self::SITE_ACCESS_KEY => array( 'placeholders' => 0 ), // Site access key:
-			self::ACCESS_KEY => array( 'placeholders' => 0 ), // Access Key
-			self::COPY_THE_ACCESS_KEY_TO_YOUR => array( 'placeholders' => 0 ), // Copy the access key to your clipboard
-			self::THE_ACCESS_KEY_IS_NOT_A => array( 'placeholders' => 1 ), // The access key is not a password; only %1$s will be able to 
-			self::YOU_ARE_LOGGED_IN_AS_A_4eed50 => array( 'placeholders' => 1 ), // You are logged in as a %s support user.
-			self::ACCESS_EXPIRES_IN_S => array( 'placeholders' => 1 ), // Access expires in %s.
-			self::YOU_WERE_ALREADY_SIGNED_IN_AS => array( 'placeholders' => 1 ), // You were already signed in as %s, so the support login was s
-			self::S_ACCESS_REVOKED => array( 'placeholders' => 1 ), // %s access revoked.
-			self::YOU_MAY_SAFELY_CLOSE_THIS_WINDOW => array( 'placeholders' => 0 ), // You may safely close this window.
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_979c0f => array( 'placeholders' => 0 ), // Support access could not be set up right now. Please try aga
-			self::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED => array( 'placeholders' => 0 ), // Support access could not be verified. Please contact the plu
-			self::THE_SUPPORT_TEAM_S_ACCOUNT_HAS => array( 'placeholders' => 0 ), // The support team's account has an issue that's preventing ac
-			self::SUPPORT_ACCESS_WAS_REFUSED_PLEASE_CONTACT => array( 'placeholders' => 0 ), // Support access was refused. Please contact the plugin's supp
-			self::THE_SUPPORT_TEAM_S_SITE_IS => array( 'placeholders' => 0 ), // The support team's site is not ready to receive access reque
-			self::THE_SUPPORT_TEAM_S_SITE_IS_6d0ab1 => array( 'placeholders' => 0 ), // The support team's site is temporarily unreachable. Please t
-			self::THE_SUPPORT_TEAM_S_SITE_RETURNED => array( 'placeholders' => 0 ), // The support team's site returned an error. Please contact th
-			self::COULD_NOT_REACH_THE_SUPPORT_TEAM => array( 'placeholders' => 0 ), // Could not reach the support team's site. Please check your i
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_084a44 => array( 'placeholders' => 1 ), // Support access could not be set up (HTTP %d). Please contact
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_829416 => array( 'placeholders' => 1 ), // Support access could not be set up. A firewall on the plugin
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_be0b5d => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_343150 => array( 'placeholders' => 1 ), // Support access could not be set up — the plugin's support 
-			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_c6bda2 => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
-			self::SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING    => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support team's site returned nothing — a firewall on their side may have blocked the request. Please contact them and share this error.
-			self::SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED      => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support team needs to finish configuring their end — please contact them and let them know.
-			self::SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support team's response was incomplete — please contact them and share this error.
-			self::SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON => array( 'placeholders' => 0 ), // Support access is temporarily disabled on this site after re
-			self::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9 => array( 'placeholders' => 1 ), // Support access could not be verified — login aborted. (%s)
-			self::UNEXPECTED_ACTION_VALUE => array( 'placeholders' => 0 ), // Unexpected action value
-			self::SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED => array( 'placeholders' => 0 ), // Support access could not be registered. Please try again in 
-			self::S_SUPPORT => array( 'placeholders' => 1 ), // %s Support
-			self::USER_NOT_CREATED_USER_WITH_THAT => array( 'placeholders' => 0 ), // User not created; User with that email already exists
+			self::REVOKE_ACCESS                           => array( 'placeholders' => 0 ),
+			self::YOU_ARE_LOGGED_IN_AS_A                  => array( 'placeholders' => 0 ),
+			self::GRANT_SUPPORT_ACCESS                    => array( 'placeholders' => 0 ),
+			self::VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE => array( 'placeholders' => 0 ),
+			self::YOU_DO_NOT_HAVE_THE_ABILITY             => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS  => array( 'placeholders' => 0 ),
+			self::THE_SUPPORT_USER_WAS_NOT_DELETED        => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET         => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_799354  => array( 'placeholders' => 0 ),
+			self::SUPPORT_LOGIN_COULD_NOT_COMPLETE        => array( 'placeholders' => 0 ),
+			self::RETURN_TO_YOUR_SUPPORT_TOOL_TO          => array( 'placeholders' => 0 ),
+			self::UNKNOWN_USER_D                          => array( 'placeholders' => 1 ),
+			self::CREATED_1_S_AGO_BY_2                    => array( 'placeholders' => 2 ),
+			self::CONTACT_S_SUPPORT                       => array( 'placeholders' => 1 ),
+			self::EMAIL_S                                 => array( 'placeholders' => 1 ),
+			self::SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE => array( 'placeholders' => 0 ),
+			self::TRY_RECONNECTING                        => array( 'placeholders' => 0 ),
+			self::SECURED_BY_TRUSTEDLOGIN                 => array( 'placeholders' => 0 ),
+			self::TERMS_OF_SERVICE                        => array( 'placeholders' => 0 ),
+			self::BY_GRANTING_ACCESS_YOU_AGREE_TO         => array( 'placeholders' => 0 ),
+			self::REFERENCE_S                             => array( 'placeholders' => 1 ),
+			self::VENDOR_HAS_SITE_ACCESS_THAT             => array( 'placeholders' => 2 ),
+			self::VISIT_VENDOR_WEBSITE                    => array( 'placeholders' => 1 ),
+			self::VENDOR_WOULD_LIKE_SUPPORT_ACCESS        => array( 'placeholders' => 1 ),
+			self::GRANT_1_S_ACCESS_TO_THIS                => array( 'placeholders' => 1 ),
+			self::INCLUDE_A_MESSAGE_FOR_SUPPORT           => array( 'placeholders' => 0 ),
+			self::PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE       => array( 'placeholders' => 0 ),
+			self::ACCESS_THIS_SITE_FOR_S                  => array( 'placeholders' => 1 ),
+			self::ACCESS_AUTO_EXPIRES_IN_S_YOU            => array( 'placeholders' => 1 ),
+			self::CREATE_A_USER_WITH_A_ROLE               => array( 'placeholders' => 1 ),
+			self::VIEW_MODIFIED_ROLE_CAPABILITIES         => array( 'placeholders' => 0 ),
+			self::CREATE_A_USER_WITH_A_ROLE_60602C        => array( 'placeholders' => 1 ),
+			self::INCLUDE_THE_LINK_SITE_HEALTH_LINK       => array( 'placeholders' => 0 ),
+			self::ADDITIONAL_CAPABILITIES                 => array( 'placeholders' => 0 ),
+			self::REMOVED_CAPABILITIES                    => array( 'placeholders' => 0 ),
+			self::S_SUPPORT_MAY_NOT_BE_ABLE               => array( 'placeholders' => 1 ),
+			self::THIS_WEBSITE_IS_RUNNING_IN_A            => array( 'placeholders' => 0 ),
+			self::LEARN_MORE                              => array( 'placeholders' => 0 ),
+			self::LEARN_ABOUT_TRUSTEDLOGIN                => array( 'placeholders' => 0 ),
+			self::TRUSTEDLOGIN_STATUS                     => array( 'placeholders' => 0 ),
+			self::OFFLINE                                 => array( 'placeholders' => 0 ),
+			self::ONLINE                                  => array( 'placeholders' => 0 ),
+			self::API_KEY                                 => array( 'placeholders' => 0 ),
+			self::LICENSE_KEY                             => array( 'placeholders' => 0 ),
+			self::LOG_URL                                 => array( 'placeholders' => 0 ),
+			self::LOG_PATH_IS_OUTSIDE_ABSPATH_NOT         => array( 'placeholders' => 0 ),
+			self::DOWNLOAD_THE_LOG                        => array( 'placeholders' => 0 ),
+			self::LOG_LEVEL                               => array( 'placeholders' => 0 ),
+			self::DEFAULT_LEVEL                           => array( 'placeholders' => 0 ),
+			self::WEBHOOK_URL                             => array( 'placeholders' => 0 ),
+			self::VENDOR_PUBLIC_KEY                       => array( 'placeholders' => 0 ),
+			self::VERIFY_KEY                              => array( 'placeholders' => 0 ),
+			self::DEBUGGING_INFO                          => array( 'placeholders' => 0 ),
+			self::TRUSTEDLOGIN_CONFIG                     => array( 'placeholders' => 0 ),
+			self::GRANT_S_ACCESS                          => array( 'placeholders' => 1 ),
+			self::EXTEND_VENDOR_ACCESS_FOR_DURATION       => array( 'placeholders' => 2 ),
+			self::COULD_NOT_CREATE_SUPPORT_ACCESS         => array( 'placeholders' => 0 ),
+			self::THE_USER_DETAILS_COULD_NOT_BE           => array( 'placeholders' => 1 ),
+			self::PLEASE_A_HREF_1_S_TARGET                => array( 'placeholders' => 2 ),
+			self::CONFIRM                                 => array( 'placeholders' => 0 ),
+			self::OK                                      => array( 'placeholders' => 0 ),
+			self::GO_TO_1_S_SUPPORT_SITE                  => array( 'placeholders' => 1 ),
+			self::CLOSE                                   => array( 'placeholders' => 0 ),
+			self::CANCEL                                  => array( 'placeholders' => 0 ),
+			self::REVOKE_1_S_SUPPORT_ACCESS               => array( 'placeholders' => 1 ),
+			self::COPY                                    => array( 'placeholders' => 0 ),
+			self::COPIED                                  => array( 'placeholders' => 0 ),
+			self::THIS_LINK_OPENS_IN_A_NEW                => array( 'placeholders' => 0 ),
+			self::THE_ACCESS_KEY_HAS_BEEN_COPIED          => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_GRANTED                  => array( 'placeholders' => 0 ),
+			self::A_TEMPORARY_SUPPORT_USER_HAS_BEEN       => array( 'placeholders' => 1 ),
+			self::GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR => array( 'placeholders' => 1 ),
+			self::EXTENDING_SUPPORT_ACCESS_FOR_1_S        => array( 'placeholders' => 2 ),
+			self::SENDING_ENCRYPTED_ACCESS_TO_1_S         => array( 'placeholders' => 1 ),
+			self::COULDN_T_REGISTER_SUPPORT_ACCESS_WITH   => array( 'placeholders' => 1 ),
+			self::ACTION_CANCELLED                        => array( 'placeholders' => 0 ),
+			self::A_SUPPORT_ACCOUNT_FOR_1_S               => array( 'placeholders' => 1 ),
+			self::SUPPORT_ACCESS_WAS_NOT_GRANTED          => array( 'placeholders' => 0 ),
+			self::THERE_WAS_AN_ERROR_GRANTING_ACCESS      => array( 'placeholders' => 0 ),
+			self::YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE => array( 'placeholders' => 0 ),
+			self::THE_REQUEST_TOOK_TOO_LONG_TO            => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_KEY_CREATED              => array( 'placeholders' => 0 ),
+			self::SHARE_THIS_ACCESS_KEY_WITH_1            => array( 'placeholders' => 1 ),
+			self::THE_SUPPORT_TEAM_S_SITE_COULD           => array( 'placeholders' => 0 ),
+			self::VENDOR_SUPPORT_USER_ALREADY_EXISTS      => array( 'placeholders' => 1 ),
+			self::A_SUPPORT_USER_FOR_1_S                  => array( 'placeholders' => 2 ),
+			self::NO_S_USERS_EXIST                        => array( 'placeholders' => 1 ),
+			self::ERROR                                   => array( 'placeholders' => 0 ),
+			self::THERE_WAS_AN_ERROR_RETURNING_THE        => array( 'placeholders' => 0 ),
+			self::SITE_ACCESS_KEY                         => array( 'placeholders' => 0 ),
+			self::ACCESS_KEY                              => array( 'placeholders' => 0 ),
+			self::COPY_THE_ACCESS_KEY_TO_YOUR             => array( 'placeholders' => 0 ),
+			self::THE_ACCESS_KEY_IS_NOT_A                 => array( 'placeholders' => 1 ),
+			self::YOU_ARE_LOGGED_IN_AS_A_4EED50           => array( 'placeholders' => 1 ),
+			self::ACCESS_EXPIRES_IN_S                     => array( 'placeholders' => 1 ),
+			self::YOU_WERE_ALREADY_SIGNED_IN_AS           => array( 'placeholders' => 1 ),
+			self::S_ACCESS_REVOKED                        => array( 'placeholders' => 1 ),
+			self::YOU_MAY_SAFELY_CLOSE_THIS_WINDOW        => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_979C0F  => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED    => array( 'placeholders' => 0 ),
+			self::THE_SUPPORT_TEAM_S_ACCOUNT_HAS          => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_WAS_REFUSED_PLEASE_CONTACT => array( 'placeholders' => 0 ),
+			self::THE_SUPPORT_TEAM_S_SITE_IS              => array( 'placeholders' => 0 ),
+			self::THE_SUPPORT_TEAM_S_SITE_IS_6D0AB1       => array( 'placeholders' => 0 ),
+			self::THE_SUPPORT_TEAM_S_SITE_RETURNED        => array( 'placeholders' => 0 ),
+			self::COULD_NOT_REACH_THE_SUPPORT_TEAM        => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_084A44  => array( 'placeholders' => 1 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_829416  => array( 'placeholders' => 1 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_BE0B5D  => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_343150  => array( 'placeholders' => 1 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_C6BDA2  => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING  => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED    => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35C1B9 => array( 'placeholders' => 1 ),
+			self::UNEXPECTED_ACTION_VALUE                 => array( 'placeholders' => 0 ),
+			self::SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED  => array( 'placeholders' => 0 ),
+			self::S_SUPPORT                               => array( 'placeholders' => 1 ),
+			self::USER_NOT_CREATED_USER_WITH_THAT         => array( 'placeholders' => 0 ),
 		);
 	}
 
@@ -355,11 +404,13 @@ class Strings {
 	}
 
 	// -----------------------------------------------------------------
-	//  Translation loading (integrator opt-in).
+	// Translation loading (integrator opt-in).
 	// -----------------------------------------------------------------
 
 	/**
 	 * Load the SDK's bundled translations against the integrator's textdomain.
+	 *
+	 * Call once from your plugin on `plugins_loaded` or `init`:
 	 *
 	 *     add_action( 'init', function () {
 	 *         \Acme\Vendor\TrustedLogin\Strings::load_translations( 'acme-plugin' );
@@ -380,12 +431,8 @@ class Strings {
 		}
 
 		if ( ! did_action( 'init' ) ) {
-			add_action(
-				'init',
-				static function () use ( $textdomain ) {
-					self::load_translations( $textdomain );
-				}
-			);
+			self::$pending_textdomain = $textdomain;
+			add_action( 'init', array( __CLASS__, 'on_init_load_translations' ) );
 			return;
 		}
 
@@ -397,17 +444,7 @@ class Strings {
 		}
 
 		if ( ! self::$translations_loaded ) {
-			// Reads self::$textdomain at fire time so a later load_translations()
-			// call wins for subsequent locale switches.
-			add_action(
-				'change_locale',
-				static function ( $new_locale ) {
-					$mo = self::mo_path_for( $new_locale );
-					if ( $mo && is_readable( $mo ) ) {
-						load_textdomain( self::$textdomain, $mo );
-					}
-				}
-			);
+			add_action( 'change_locale', array( __CLASS__, 'on_change_locale' ) );
 			self::$translations_loaded = true;
 		}
 	}
@@ -419,7 +456,7 @@ class Strings {
 	 * the SDK is at `wp-content/plugins/foo/vendor_prefixed/trustedlogin/
 	 * client/src/Strings.php` (Strauss layout) or anywhere else.
 	 *
-	 * @param string $locale
+	 * @param string $locale Locale code (e.g. `de_DE`).
 	 *
 	 * @return string
 	 */
@@ -427,11 +464,11 @@ class Strings {
 		if ( ! is_string( $locale ) || '' === $locale ) {
 			return '';
 		}
-		return dirname( __FILE__ ) . '/languages/trustedlogin-' . $locale . '.mo';
+		return __DIR__ . '/languages/trustedlogin-' . $locale . '.mo';
 	}
 
 	// -----------------------------------------------------------------
-	//  Translation accessor (called by SDK internals).
+	// Translation accessor (called by SDK internals).
 	// -----------------------------------------------------------------
 
 	/**
@@ -472,16 +509,16 @@ class Strings {
 	 *
 	 * @since 1.11.0
 	 *
-	 * @param string $key      A {@see self} class constant.
-	 * @param string $default  The SDK's English default. Already translated
-	 *                         by the caller's literal `__()`/`_n()` call.
-	 * @param array  $context  Positional args passed to a closure override
-	 *                         (e.g. `array( $count )` for a plural).
+	 * @param string $key          A {@see self} class constant.
+	 * @param string $default_text The SDK's English default. Already translated
+	 *                             by the caller's literal `__()`/`_n()` call.
+	 * @param array  $context      Positional args passed to a closure override
+	 *                             (e.g. `array( $count )` for a plural).
 	 *
 	 * @return string
 	 */
-	public static function get( $key, $default, array $context = array() ) {
-		$value = self::resolve( $key, $default, $context );
+	public static function get( $key, $default_text, array $context = array() ) {
+		$value = self::resolve( $key, $default_text, $context );
 
 		// Without an `init()` call the filter has no namespace to attach
 		// to. Return the resolved value without filtering — same English
@@ -508,7 +545,7 @@ class Strings {
 					$context,
 					self::$config
 				);
-			} catch ( \Throwable $e ) {
+			} catch ( \Exception $e ) {
 				self::log_closure_failure( $key, $e );
 			}
 		}
@@ -521,7 +558,8 @@ class Strings {
 		if ( isset( $registry[ $key ]['placeholders'] ) ) {
 			$expected = (int) $registry[ $key ]['placeholders'];
 			if ( self::count_placeholders( $value ) > $expected ) {
-				return (string) translate( (string) $default, self::$textdomain );
+				// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
+				return (string) translate( (string) $default_text, self::$textdomain );
 			}
 		}
 
@@ -536,7 +574,7 @@ class Strings {
 	 *
 	 * @since 1.11.0
 	 *
-	 * @param mixed $s
+	 * @param mixed $s Candidate string to scan; non-strings return 0.
 	 *
 	 * @return int Number of distinct args the string consumes.
 	 */
@@ -558,13 +596,17 @@ class Strings {
 	}
 
 	/**
-	 * @param string $key
-	 * @param string $default
-	 * @param array  $context
+	 * Resolve a key against overrides, falling back to the SDK default.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key          A {@see self} class constant.
+	 * @param string $default_text The SDK's English default.
+	 * @param array  $context      Positional args for a closure override.
 	 *
 	 * @return string
 	 */
-	private static function resolve( $key, $default, array $context ) {
+	private static function resolve( $key, $default_text, array $context ) {
 		if ( array_key_exists( $key, self::$overrides ) ) {
 			$override = self::$overrides[ $key ];
 
@@ -579,17 +621,18 @@ class Strings {
 			if ( is_callable( $override ) ) {
 				try {
 					return (string) call_user_func_array( $override, array_values( $context ) );
-				} catch ( \Throwable $e ) {
+				} catch ( \Exception $e ) {
 					self::log_closure_failure( $key, $e );
 				}
 			}
 		}
 
 		try {
-			return (string) translate( (string) $default, self::$textdomain );
-		} catch ( \Throwable $e ) {
+			// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
+			return (string) translate( (string) $default_text, self::$textdomain );
+		} catch ( \Exception $e ) {
 			self::log_closure_failure( $key, $e );
-			return (string) $default;
+			return (string) $default_text;
 		}
 	}
 
@@ -603,9 +646,9 @@ class Strings {
 	 * @since 1.11.0
 	 *
 	 * @param string     $key The Strings constant whose resolution failed.
-	 * @param \Throwable $e   The exception or error from the integrator callback.
+	 * @param \Exception $e   The exception or error from the integrator callback.
 	 */
-	private static function log_closure_failure( $key, \Throwable $e ) {
+	private static function log_closure_failure( $key, \Exception $e ) {
 		if ( ! self::$config instanceof Config ) {
 			return;
 		}

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -40,11 +40,125 @@ class Strings {
 	//  Constants are stable across versions (renames are breaking).
 	// -----------------------------------------------------------------
 
-	const SECURED_BY                     = 'secured_by';
-	const REVOKE_ACCESS_BUTTON           = 'revoke_access_button';
-	const SUPPORT_TEMPORARILY_UNAVAILABLE = 'support_temporarily_unavailable';
-	const TRY_RECONNECTING               = 'try_reconnecting';
-	const CREATED_TIME_AGO               = 'created_time_ago';
+	const REVOKE_ACCESS = 'revoke_access';
+	const YOU_ARE_LOGGED_IN_AS_A = 'you_are_logged_in_as_a';
+	const GRANT_SUPPORT_ACCESS = 'grant_support_access';
+	const VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE = 'verification_issue_request_could_not_be';
+	const YOU_DO_NOT_HAVE_THE_ABILITY = 'you_do_not_have_the_ability';
+	const SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS = 'support_access_requires_a_secure_https';
+	const THE_SUPPORT_USER_WAS_NOT_DELETED = 'the_support_user_was_not_deleted';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET = 'support_access_could_not_be_set';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_799354 = 'support_access_could_not_be_set_799354';
+	const SUPPORT_LOGIN_COULD_NOT_COMPLETE = 'support_login_could_not_complete';
+	const RETURN_TO_YOUR_SUPPORT_TOOL_TO = 'return_to_your_support_tool_to';
+	const UNKNOWN_USER_D = 'unknown_user_d';
+	const CREATED_1_S_AGO_BY_2 = 'created_1_s_ago_by_2';
+	const CONTACT_S_SUPPORT = 'contact_s_support';
+	const EMAIL_S = 'email_s';
+	const SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE = 'support_access_is_temporarily_unavailable_please';
+	const TRY_RECONNECTING = 'try_reconnecting';
+	const SECURED_BY_TRUSTEDLOGIN = 'secured_by_trustedlogin';
+	const TERMS_OF_SERVICE = 'terms_of_service';
+	const BY_GRANTING_ACCESS_YOU_AGREE_TO = 'by_granting_access_you_agree_to';
+	const REFERENCE_S = 'reference_s';
+	const VENDOR_HAS_SITE_ACCESS_THAT = '1_s_has_site_access_that';
+	const VENDOR_WOULD_LIKE_SUPPORT_ACCESS = '1_s_would_like_support_access';
+	const GRANT_1_S_ACCESS_TO_THIS = 'grant_1_s_access_to_this';
+	const INCLUDE_A_MESSAGE_FOR_SUPPORT = 'include_a_message_for_support';
+	const PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE = 'please_describe_the_issue_you_are';
+	const ACCESS_THIS_SITE_FOR_S = 'access_this_site_for_s';
+	const ACCESS_AUTO_EXPIRES_IN_S_YOU = 'access_auto_expires_in_s_you';
+	const CREATE_A_USER_WITH_A_ROLE = 'create_a_user_with_a_role';
+	const VIEW_MODIFIED_ROLE_CAPABILITIES = 'view_modified_role_capabilities';
+	const CREATE_A_USER_WITH_A_ROLE_60602c = 'create_a_user_with_a_role_60602c';
+	const INCLUDE_THE_LINK_SITE_HEALTH_LINK = 'include_the_link_site_health_link';
+	const ADDITIONAL_CAPABILITIES = 'additional_capabilities';
+	const REMOVED_CAPABILITIES = 'removed_capabilities';
+	const S_SUPPORT_MAY_NOT_BE_ABLE = 's_support_may_not_be_able';
+	const THIS_WEBSITE_IS_RUNNING_IN_A = 'this_website_is_running_in_a';
+	const LEARN_MORE = 'learn_more';
+	const LEARN_ABOUT_TRUSTEDLOGIN = 'learn_about_trustedlogin';
+	const TRUSTEDLOGIN_STATUS = 'trustedlogin_status';
+	const OFFLINE = 'offline';
+	const ONLINE = 'online';
+	const API_KEY = 'api_key';
+	const LICENSE_KEY = 'license_key';
+	const LOG_URL = 'log_url';
+	const LOG_PATH_IS_OUTSIDE_ABSPATH_NOT = 'log_path_is_outside_abspath_not';
+	const DOWNLOAD_THE_LOG = 'download_the_log';
+	const LOG_LEVEL = 'log_level';
+	const DEFAULT = 'default';
+	const WEBHOOK_URL = 'webhook_url';
+	const VENDOR_PUBLIC_KEY = 'vendor_public_key';
+	const VERIFY_KEY = 'verify_key';
+	const DEBUGGING_INFO = 'debugging_info';
+	const TRUSTEDLOGIN_CONFIG = 'trustedlogin_config';
+	const GRANT_S_ACCESS = 'grant_s_access';
+	const EXTEND_S_ACCESS = 'extend_s_access';
+	const COULD_NOT_CREATE_SUPPORT_ACCESS = 'could_not_create_support_access';
+	const THE_USER_DETAILS_COULD_NOT_BE = 'the_user_details_could_not_be';
+	const PLEASE_A_HREF_1_S_TARGET = 'please_a_href_1_s_target';
+	const CONFIRM = 'confirm';
+	const OK = 'ok';
+	const GO_TO_1_S_SUPPORT_SITE = 'go_to_1_s_support_site';
+	const CLOSE = 'close';
+	const CANCEL = 'cancel';
+	const REVOKE_1_S_SUPPORT_ACCESS = 'revoke_1_s_support_access';
+	const COPY = 'copy';
+	const COPIED = 'copied';
+	const THIS_LINK_OPENS_IN_A_NEW = 'this_link_opens_in_a_new';
+	const THE_ACCESS_KEY_HAS_BEEN_COPIED = 'the_access_key_has_been_copied';
+	const SUPPORT_ACCESS_GRANTED = 'support_access_granted';
+	const A_TEMPORARY_SUPPORT_USER_HAS_BEEN = 'a_temporary_support_user_has_been';
+	const GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR = 'generating_encrypting_secure_support_access_for';
+	const EXTENDING_SUPPORT_ACCESS_FOR_1_S = 'extending_support_access_for_1_s';
+	const SENDING_ENCRYPTED_ACCESS_TO_1_S = 'sending_encrypted_access_to_1_s';
+	const COULDN_T_REGISTER_SUPPORT_ACCESS_WITH = 'couldn_t_register_support_access_with';
+	const ACTION_CANCELLED = 'action_cancelled';
+	const A_SUPPORT_ACCOUNT_FOR_1_S = 'a_support_account_for_1_s';
+	const SUPPORT_ACCESS_WAS_NOT_GRANTED = 'support_access_was_not_granted';
+	const THERE_WAS_AN_ERROR_GRANTING_ACCESS = 'there_was_an_error_granting_access';
+	const YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE = 'your_authorized_session_has_expired_please';
+	const THE_REQUEST_TOOK_TOO_LONG_TO = 'the_request_took_too_long_to';
+	const SUPPORT_ACCESS_KEY_CREATED = 'support_access_key_created';
+	const SHARE_THIS_ACCESS_KEY_WITH_1 = 'share_this_access_key_with_1';
+	const THE_SUPPORT_TEAM_S_SITE_COULD = 'the_support_team_s_site_could';
+	const VENDOR_SUPPORT_USER_ALREADY_EXISTS = '1_s_support_user_already_exists';
+	const A_SUPPORT_USER_FOR_1_S = 'a_support_user_for_1_s';
+	const NO_S_USERS_EXIST = 'no_s_users_exist';
+	const ERROR = 'error';
+	const THERE_WAS_AN_ERROR_RETURNING_THE = 'there_was_an_error_returning_the';
+	const SITE_ACCESS_KEY = 'site_access_key';
+	const ACCESS_KEY = 'access_key';
+	const COPY_THE_ACCESS_KEY_TO_YOUR = 'copy_the_access_key_to_your';
+	const THE_ACCESS_KEY_IS_NOT_A = 'the_access_key_is_not_a';
+	const YOU_ARE_LOGGED_IN_AS_A_4eed50 = 'you_are_logged_in_as_a_4eed50';
+	const ACCESS_EXPIRES_IN_S = 'access_expires_in_s';
+	const YOU_WERE_ALREADY_SIGNED_IN_AS = 'you_were_already_signed_in_as';
+	const S_ACCESS_REVOKED = 's_access_revoked';
+	const YOU_MAY_SAFELY_CLOSE_THIS_WINDOW = 'you_may_safely_close_this_window';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_979c0f = 'support_access_could_not_be_set_979c0f';
+	const SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED = 'support_access_could_not_be_verified';
+	const THE_SUPPORT_TEAM_S_ACCOUNT_HAS = 'the_support_team_s_account_has';
+	const SUPPORT_ACCESS_WAS_REFUSED_PLEASE_CONTACT = 'support_access_was_refused_please_contact';
+	const THE_SUPPORT_TEAM_S_SITE_IS = 'the_support_team_s_site_is';
+	const THE_SUPPORT_TEAM_S_SITE_IS_6d0ab1 = 'the_support_team_s_site_is_6d0ab1';
+	const THE_SUPPORT_TEAM_S_SITE_RETURNED = 'the_support_team_s_site_returned';
+	const COULD_NOT_REACH_THE_SUPPORT_TEAM = 'could_not_reach_the_support_team';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_084a44 = 'support_access_could_not_be_set_084a44';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_829416 = 'support_access_could_not_be_set_829416';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_be0b5d = 'support_access_could_not_be_set_be0b5d';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_343150 = 'support_access_could_not_be_set_343150';
+	const SUPPORT_ACCESS_COULD_NOT_BE_SET_c6bda2 = 'support_access_could_not_be_set_c6bda2';
+	const SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING    = 'support_access_vendor_returned_nothing';
+	const SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED      = 'support_access_vendor_not_configured';
+	const SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE = 'support_access_vendor_response_incomplete';
+	const SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON = 'support_access_is_temporarily_disabled_on';
+	const SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9 = 'support_access_could_not_be_verified_35c1b9';
+	const UNEXPECTED_ACTION_VALUE = 'unexpected_action_value';
+	const SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED = 'support_access_could_not_be_registered';
+	const S_SUPPORT = 's_support';
+	const USER_NOT_CREATED_USER_WITH_THAT = 'user_not_created_user_with_that';
 
 	/**
 	 * Textdomain that runtime translation lookups should hit. Set by
@@ -95,11 +209,125 @@ class Strings {
 	 */
 	public static function registry() {
 		return array(
-			self::SECURED_BY                      => array( 'placeholders' => 0 ),
-			self::REVOKE_ACCESS_BUTTON            => array( 'placeholders' => 0 ),
-			self::SUPPORT_TEMPORARILY_UNAVAILABLE => array( 'placeholders' => 0 ),
-			self::TRY_RECONNECTING                => array( 'placeholders' => 0 ),
-			self::CREATED_TIME_AGO                => array( 'placeholders' => 2 ),
+			self::REVOKE_ACCESS => array( 'placeholders' => 0 ), // Revoke Access
+			self::YOU_ARE_LOGGED_IN_AS_A => array( 'placeholders' => 0 ), // You are logged in as a support user. Click to permanently re
+			self::GRANT_SUPPORT_ACCESS => array( 'placeholders' => 0 ), // Grant Support Access
+			self::VERIFICATION_ISSUE_REQUEST_COULD_NOT_BE => array( 'placeholders' => 0 ), // Verification issue: Request could not be verified. Please re
+			self::YOU_DO_NOT_HAVE_THE_ABILITY => array( 'placeholders' => 0 ), // You do not have the ability to create users.
+			self::SUPPORT_ACCESS_REQUIRES_A_SECURE_HTTPS => array( 'placeholders' => 0 ), // Support access requires a secure (HTTPS) connection. Please 
+			self::THE_SUPPORT_USER_WAS_NOT_DELETED => array( 'placeholders' => 0 ), // The support user was not deleted.
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_799354 => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
+			self::SUPPORT_LOGIN_COULD_NOT_COMPLETE => array( 'placeholders' => 0 ), // Support login could not complete
+			self::RETURN_TO_YOUR_SUPPORT_TOOL_TO => array( 'placeholders' => 0 ), // Return to your support tool to try again.
+			self::UNKNOWN_USER_D => array( 'placeholders' => 1 ), // Unknown (User #%d)
+			self::CREATED_1_S_AGO_BY_2 => array( 'placeholders' => 2 ), // Created %1$s ago by %2$s
+			self::CONTACT_S_SUPPORT => array( 'placeholders' => 1 ), // Contact %s support
+			self::EMAIL_S => array( 'placeholders' => 1 ), // Email %s
+			self::SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE => array( 'placeholders' => 0 ), // Support access is temporarily unavailable. Please try again 
+			self::TRY_RECONNECTING => array( 'placeholders' => 0 ), // Try reconnecting
+			self::SECURED_BY_TRUSTEDLOGIN => array( 'placeholders' => 0 ), // Secured by TrustedLogin
+			self::TERMS_OF_SERVICE => array( 'placeholders' => 0 ), // Terms of Service
+			self::BY_GRANTING_ACCESS_YOU_AGREE_TO => array( 'placeholders' => 0 ), // By granting access, you agree to the {{tos_link}}.
+			self::REFERENCE_S => array( 'placeholders' => 1 ), // Reference #%s
+			self::VENDOR_HAS_SITE_ACCESS_THAT => array( 'placeholders' => 2 ), // %1$s has site access that expires in %2$s.
+			self::VENDOR_WOULD_LIKE_SUPPORT_ACCESS => array( 'placeholders' => 1 ), // %1$s would like support access to this site.
+			self::GRANT_1_S_ACCESS_TO_THIS => array( 'placeholders' => 1 ), // Grant %1$s access to this site.
+			self::INCLUDE_A_MESSAGE_FOR_SUPPORT => array( 'placeholders' => 0 ), // Include a message for support?
+			self::PLEASE_DESCRIBE_THE_ISSUE_YOU_ARE => array( 'placeholders' => 0 ), // Please describe the issue you are having.
+			self::ACCESS_THIS_SITE_FOR_S => array( 'placeholders' => 1 ), // Access this site for %s.
+			self::ACCESS_AUTO_EXPIRES_IN_S_YOU => array( 'placeholders' => 1 ), // Access auto-expires in %s. You may revoke access at any time
+			self::CREATE_A_USER_WITH_A_ROLE => array( 'placeholders' => 1 ), // Create a user with a role based on %s.
+			self::VIEW_MODIFIED_ROLE_CAPABILITIES => array( 'placeholders' => 0 ), // View modified role capabilities
+			self::CREATE_A_USER_WITH_A_ROLE_60602c => array( 'placeholders' => 1 ), // Create a user with a role of %s.
+			self::INCLUDE_THE_LINK_SITE_HEALTH_LINK => array( 'placeholders' => 0 ), // Include the [link]Site Health[/link] troubleshooting report
+			self::ADDITIONAL_CAPABILITIES => array( 'placeholders' => 0 ), // Additional capabilities:
+			self::REMOVED_CAPABILITIES => array( 'placeholders' => 0 ), // Removed capabilities:
+			self::S_SUPPORT_MAY_NOT_BE_ABLE => array( 'placeholders' => 1 ), // %s support may not be able to access this site.
+			self::THIS_WEBSITE_IS_RUNNING_IN_A => array( 'placeholders' => 0 ), // This website is running in a local development environment. 
+			self::LEARN_MORE => array( 'placeholders' => 0 ), // Learn more.
+			self::LEARN_ABOUT_TRUSTEDLOGIN => array( 'placeholders' => 0 ), // Learn about TrustedLogin
+			self::TRUSTEDLOGIN_STATUS => array( 'placeholders' => 0 ), // TrustedLogin Status
+			self::OFFLINE => array( 'placeholders' => 0 ), // Offline
+			self::ONLINE => array( 'placeholders' => 0 ), // Online
+			self::API_KEY => array( 'placeholders' => 0 ), // API Key
+			self::LICENSE_KEY => array( 'placeholders' => 0 ), // License Key
+			self::LOG_URL => array( 'placeholders' => 0 ), // Log URL
+			self::LOG_PATH_IS_OUTSIDE_ABSPATH_NOT => array( 'placeholders' => 0 ), // (Log path is outside ABSPATH; not exposing as URL.)
+			self::DOWNLOAD_THE_LOG => array( 'placeholders' => 0 ), // Download the log
+			self::LOG_LEVEL => array( 'placeholders' => 0 ), // Log Level
+			self::DEFAULT => array( 'placeholders' => 0 ), // (Default)
+			self::WEBHOOK_URL => array( 'placeholders' => 0 ), // Webhook URL
+			self::VENDOR_PUBLIC_KEY => array( 'placeholders' => 0 ), // Vendor Public Key
+			self::VERIFY_KEY => array( 'placeholders' => 0 ), // Verify key
+			self::DEBUGGING_INFO => array( 'placeholders' => 0 ), // Debugging Info
+			self::TRUSTEDLOGIN_CONFIG => array( 'placeholders' => 0 ), // TrustedLogin Config
+			self::GRANT_S_ACCESS => array( 'placeholders' => 1 ), // Grant %s Access
+			self::EXTEND_S_ACCESS => array( 'placeholders' => 1 ), // Extend %s Access
+			self::COULD_NOT_CREATE_SUPPORT_ACCESS => array( 'placeholders' => 0 ), // Could not create support access.
+			self::THE_USER_DETAILS_COULD_NOT_BE => array( 'placeholders' => 1 ), // The user details could not be sent to %1$s automatically.
+			self::PLEASE_A_HREF_1_S_TARGET => array( 'placeholders' => 2 ), // Please <a href="%1$s" target="_blank">click here</a> to go t
+			self::CONFIRM => array( 'placeholders' => 0 ), // Confirm
+			self::OK => array( 'placeholders' => 0 ), // Ok
+			self::GO_TO_1_S_SUPPORT_SITE => array( 'placeholders' => 1 ), // Go to %1$s support site
+			self::CLOSE => array( 'placeholders' => 0 ), // Close
+			self::CANCEL => array( 'placeholders' => 0 ), // Cancel
+			self::REVOKE_1_S_SUPPORT_ACCESS => array( 'placeholders' => 1 ), // Revoke %1$s support access
+			self::COPY => array( 'placeholders' => 0 ), // Copy
+			self::COPIED => array( 'placeholders' => 0 ), // Copied!
+			self::THIS_LINK_OPENS_IN_A_NEW => array( 'placeholders' => 0 ), // (This link opens in a new window.)
+			self::THE_ACCESS_KEY_HAS_BEEN_COPIED => array( 'placeholders' => 0 ), // The access key has been copied to your clipboard.
+			self::SUPPORT_ACCESS_GRANTED => array( 'placeholders' => 0 ), // Support access granted
+			self::A_TEMPORARY_SUPPORT_USER_HAS_BEEN => array( 'placeholders' => 1 ), // A temporary support user has been created, and sent to %1$s 
+			self::GENERATING_ENCRYPTING_SECURE_SUPPORT_ACCESS_FOR => array( 'placeholders' => 1 ), // Generating & encrypting secure support access for %1$s
+			self::EXTENDING_SUPPORT_ACCESS_FOR_1_S => array( 'placeholders' => 2 ), // Extending support access for %1$s by %2$s
+			self::SENDING_ENCRYPTED_ACCESS_TO_1_S => array( 'placeholders' => 1 ), // Sending encrypted access to %1$s.
+			self::COULDN_T_REGISTER_SUPPORT_ACCESS_WITH => array( 'placeholders' => 1 ), // Couldn't register support access with %1$s
+			self::ACTION_CANCELLED => array( 'placeholders' => 0 ), // Action Cancelled
+			self::A_SUPPORT_ACCOUNT_FOR_1_S => array( 'placeholders' => 1 ), // A support account for %1$s was not created.
+			self::SUPPORT_ACCESS_WAS_NOT_GRANTED => array( 'placeholders' => 0 ), // Support Access Was Not Granted
+			self::THERE_WAS_AN_ERROR_GRANTING_ACCESS => array( 'placeholders' => 0 ), // There was an error granting access: 
+			self::YOUR_AUTHORIZED_SESSION_HAS_EXPIRED_PLEASE => array( 'placeholders' => 0 ), // Your authorized session has expired. Please refresh the page
+			self::THE_REQUEST_TOOK_TOO_LONG_TO => array( 'placeholders' => 0 ), // The request took too long to complete. Please try again.
+			self::SUPPORT_ACCESS_KEY_CREATED => array( 'placeholders' => 0 ), // Support Access Key Created
+			self::SHARE_THIS_ACCESS_KEY_WITH_1 => array( 'placeholders' => 1 ), // Share this access key with %1$s to give them secure access:
+			self::THE_SUPPORT_TEAM_S_SITE_COULD => array( 'placeholders' => 0 ), // The support team's site could not be found.
+			self::VENDOR_SUPPORT_USER_ALREADY_EXISTS => array( 'placeholders' => 1 ), // %1$s Support user already exists
+			self::A_SUPPORT_USER_FOR_1_S => array( 'placeholders' => 2 ), // A support user for %1$s already exists. You may revoke this 
+			self::NO_S_USERS_EXIST => array( 'placeholders' => 1 ), // No %s users exist.
+			self::ERROR => array( 'placeholders' => 0 ), // Error
+			self::THERE_WAS_AN_ERROR_RETURNING_THE => array( 'placeholders' => 0 ), // There was an error returning the access key.
+			self::SITE_ACCESS_KEY => array( 'placeholders' => 0 ), // Site access key:
+			self::ACCESS_KEY => array( 'placeholders' => 0 ), // Access Key
+			self::COPY_THE_ACCESS_KEY_TO_YOUR => array( 'placeholders' => 0 ), // Copy the access key to your clipboard
+			self::THE_ACCESS_KEY_IS_NOT_A => array( 'placeholders' => 1 ), // The access key is not a password; only %1$s will be able to 
+			self::YOU_ARE_LOGGED_IN_AS_A_4eed50 => array( 'placeholders' => 1 ), // You are logged in as a %s support user.
+			self::ACCESS_EXPIRES_IN_S => array( 'placeholders' => 1 ), // Access expires in %s.
+			self::YOU_WERE_ALREADY_SIGNED_IN_AS => array( 'placeholders' => 1 ), // You were already signed in as %s, so the support login was s
+			self::S_ACCESS_REVOKED => array( 'placeholders' => 1 ), // %s access revoked.
+			self::YOU_MAY_SAFELY_CLOSE_THIS_WINDOW => array( 'placeholders' => 0 ), // You may safely close this window.
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_979c0f => array( 'placeholders' => 0 ), // Support access could not be set up right now. Please try aga
+			self::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED => array( 'placeholders' => 0 ), // Support access could not be verified. Please contact the plu
+			self::THE_SUPPORT_TEAM_S_ACCOUNT_HAS => array( 'placeholders' => 0 ), // The support team's account has an issue that's preventing ac
+			self::SUPPORT_ACCESS_WAS_REFUSED_PLEASE_CONTACT => array( 'placeholders' => 0 ), // Support access was refused. Please contact the plugin's supp
+			self::THE_SUPPORT_TEAM_S_SITE_IS => array( 'placeholders' => 0 ), // The support team's site is not ready to receive access reque
+			self::THE_SUPPORT_TEAM_S_SITE_IS_6d0ab1 => array( 'placeholders' => 0 ), // The support team's site is temporarily unreachable. Please t
+			self::THE_SUPPORT_TEAM_S_SITE_RETURNED => array( 'placeholders' => 0 ), // The support team's site returned an error. Please contact th
+			self::COULD_NOT_REACH_THE_SUPPORT_TEAM => array( 'placeholders' => 0 ), // Could not reach the support team's site. Please check your i
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_084a44 => array( 'placeholders' => 1 ), // Support access could not be set up (HTTP %d). Please contact
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_829416 => array( 'placeholders' => 1 ), // Support access could not be set up. A firewall on the plugin
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_be0b5d => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_343150 => array( 'placeholders' => 1 ), // Support access could not be set up — the plugin's support 
+			self::SUPPORT_ACCESS_COULD_NOT_BE_SET_c6bda2 => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support tea
+			self::SUPPORT_ACCESS_VENDOR_RETURNED_NOTHING    => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support team's site returned nothing — a firewall on their side may have blocked the request. Please contact them and share this error.
+			self::SUPPORT_ACCESS_VENDOR_NOT_CONFIGURED      => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support team needs to finish configuring their end — please contact them and let them know.
+			self::SUPPORT_ACCESS_VENDOR_RESPONSE_INCOMPLETE => array( 'placeholders' => 0 ), // Support access could not be set up. The plugin's support team's response was incomplete — please contact them and share this error.
+			self::SUPPORT_ACCESS_IS_TEMPORARILY_DISABLED_ON => array( 'placeholders' => 0 ), // Support access is temporarily disabled on this site after re
+			self::SUPPORT_ACCESS_COULD_NOT_BE_VERIFIED_35c1b9 => array( 'placeholders' => 1 ), // Support access could not be verified — login aborted. (%s)
+			self::UNEXPECTED_ACTION_VALUE => array( 'placeholders' => 0 ), // Unexpected action value
+			self::SUPPORT_ACCESS_COULD_NOT_BE_REGISTERED => array( 'placeholders' => 0 ), // Support access could not be registered. Please try again in 
+			self::S_SUPPORT => array( 'placeholders' => 1 ), // %s Support
+			self::USER_NOT_CREATED_USER_WITH_THAT => array( 'placeholders' => 0 ), // User not created; User with that email already exists
 		);
 	}
 

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -187,19 +187,12 @@ class Strings {
 	private static $overrides = array();
 
 	/**
-	 * Bind the SDK's Strings utility to the active Config.
-	 *
-	 * Must be called once during SDK bootstrap — `Client::__construct()`
-	 * does this. Subsequent `Strings::get()` calls read the integrator's
-	 * override map and the namespace for the runtime filter from the
-	 * Config bound here.
-	 *
-	 * Calling `init()` again replaces the bound Config (useful in tests
-	 * that exercise multiple Configs in sequence; pair with reset()).
+	 * Bind the active Config. Subsequent `get()` calls read overrides
+	 * and the runtime filter namespace from it.
 	 *
 	 * @since 1.11.0
 	 *
-	 * @param Config $config Active configuration.
+	 * @param Config $config
 	 */
 	public static function init( Config $config ) {
 		self::$config    = $config;
@@ -207,9 +200,7 @@ class Strings {
 	}
 
 	/**
-	 * Test seam: clear all bound state so the next `init()` starts fresh.
-	 *
-	 * Used by PHPUnit tearDown to prevent override leaks between tests.
+	 * Clear all bound state.
 	 *
 	 * @since 1.11.0
 	 */
@@ -220,11 +211,6 @@ class Strings {
 		self::$translations_loaded = false;
 	}
 
-	// -----------------------------------------------------------------
-	//  Registry — declared shape of every overrideable key. Used by
-	//  Config::validate_strings() to reject malformed overrides before
-	//  they reach sprintf.
-	// -----------------------------------------------------------------
 
 	/**
 	 * @return array<string, array{placeholders:int}>
@@ -375,24 +361,12 @@ class Strings {
 	/**
 	 * Load the SDK's bundled translations against the integrator's textdomain.
 	 *
-	 * Call once from `plugins_loaded` or `init` in your plugin:
-	 *
 	 *     add_action( 'init', function () {
 	 *         \Acme\Vendor\TrustedLogin\Strings::load_translations( 'acme-plugin' );
 	 *     } );
 	 *
-	 * The SDK ships `.mo` files in `src/languages/`. Routing them through
-	 * YOUR textdomain (which Strauss renamed to your plugin's unique
-	 * prefix at build time) sidesteps the multi-SDK textdomain collision
-	 * that would otherwise occur when two TL-using plugins are active on
-	 * the same site.
-	 *
-	 * Hooked on `change_locale` to reload after `switch_to_locale()` /
-	 * `restore_previous_locale()` — fires for emails, REST, multilingual
-	 * plugins.
-	 *
-	 * Skips silently when called before `init` (WP 6.7+ rule against
-	 * early `__()` calls; we honor it for textdomain loading too).
+	 * Defers automatically when called before `init` (avoids the WP 6.7+
+	 * early-translation deprecation notice).
 	 *
 	 * @since 1.11.0
 	 *
@@ -405,8 +379,6 @@ class Strings {
 			return;
 		}
 
-		// WP 6.7+ emits a deprecation notice when translation work
-		// happens before `init`. Defer if we got here too early.
 		if ( ! did_action( 'init' ) ) {
 			add_action(
 				'init',
@@ -425,11 +397,8 @@ class Strings {
 		}
 
 		if ( ! self::$translations_loaded ) {
-			// Read self::$textdomain at fire time (not captured by
-			// value). If load_translations() is called again with a
-			// different domain BEFORE this hook fires, the second
-			// call's textdomain wins for the reload — matching the
-			// most recent `self::$textdomain` write at line 418.
+			// Reads self::$textdomain at fire time so a later load_translations()
+			// call wins for subsequent locale switches.
 			add_action(
 				'change_locale',
 				static function ( $new_locale ) {
@@ -540,28 +509,14 @@ class Strings {
 					self::$config
 				);
 			} catch ( \Throwable $e ) {
-				// An integrator filter callback that throws should NOT
-				// fatal the SDK. Keep whatever resolve() produced and
-				// log so the integrator can diagnose.
 				self::log_closure_failure( $key, $e );
 			}
 		}
 
-		// Runtime sprintf safety net.
-		//
-		// Static-string overrides are placeholder-validated at Config-
-		// load time, but closures (which return arbitrary strings) and
-		// the runtime filter (which can mutate $value to anything) both
-		// bypass that gate. If their result has MORE placeholders than
-		// the SDK call site is about to sprintf into, PHP 8 throws
-		// ValueError "Too few arguments" — an uncaught fatal that
-		// blows up the consent screen on the customer's site.
-		//
-		// Defense: count placeholders in the resolved value. If it
-		// exceeds the registry-declared count, fall back to a fresh
-		// translation of the default — which we know has exactly the
-		// expected placeholder count because every SDK call site is
-		// hand-authored against it.
+		// PHP 8 fatals on `sprintf` "too few args". If a closure or
+		// filter produced more placeholders than the registry declares,
+		// fall back to the default rather than let it reach the
+		// caller's sprintf.
 		$registry = self::registry();
 		if ( isset( $registry[ $key ]['placeholders'] ) ) {
 			$expected = (int) $registry[ $key ]['placeholders'];
@@ -622,64 +577,43 @@ class Strings {
 			}
 
 			if ( is_callable( $override ) ) {
-				// Catch \Throwable (covers Exception + Error in PHP 7+).
-				// An integrator closure that throws — null pointer,
-				// undefined variable in their callable, DB query
-				// timeout, etc. — would otherwise propagate out of
-				// the SDK as a fatal. Fall back to the SDK default
-				// so the consent screen stays alive.
 				try {
 					return (string) call_user_func_array( $override, array_values( $context ) );
 				} catch ( \Throwable $e ) {
-					// Best-effort log via the active Config's logger.
-					// If logging isn't wired (no init yet, no logging
-					// instance reachable), the SDK silently falls back.
 					self::log_closure_failure( $key, $e );
 				}
 			}
-
-			// Shape mismatch should have been caught by Config::validate_strings().
-			// Belt-and-suspenders fallback to default.
 		}
 
-		// No override (or malformed). Translate the SDK's English default
-		// against whichever textdomain the integrator routed our `.mo`
-		// files through. When no `.mo` is loaded under that domain,
-		// translate() returns the input verbatim — English fallback.
 		try {
 			return (string) translate( (string) $default, self::$textdomain );
 		} catch ( \Throwable $e ) {
-			// gettext-translations can theoretically throw on a
-			// malformed .mo file; treat as English fallback.
 			self::log_closure_failure( $key, $e );
 			return (string) $default;
 		}
 	}
 
 	/**
-	 * Best-effort log of an integrator-code failure inside Strings
-	 * resolution. Silent fallback if the Logging surface isn't
-	 * reachable — better than letting the exception propagate.
+	 * Log an integrator-code failure through the SDK's logging surface.
+	 *
+	 * Routes through {@see Logging} so messages share the namespaced
+	 * log file and the `logging/enabled` gate with the rest of the SDK.
+	 * No-op when `init()` hasn't been called yet (no Config bound).
 	 *
 	 * @since 1.11.0
 	 *
-	 * @param string     $key The Strings constant being resolved.
-	 * @param \Throwable $e   The error.
+	 * @param string     $key The Strings constant whose resolution failed.
+	 * @param \Throwable $e   The exception or error from the integrator callback.
 	 */
 	private static function log_closure_failure( $key, \Throwable $e ) {
 		if ( ! self::$config instanceof Config ) {
 			return;
 		}
-		// Use error_log() as the minimal sink. The SDK's Logging class
-		// has heavier deps; resolve() is too hot a path to construct
-		// one. The integrator can hook 'gettext'/php error-log to
-		// route as needed.
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			error_log( sprintf(
-				'[TrustedLogin] Strings::%s resolution failed: %s',
-				$key,
-				$e->getMessage()
-			) );
-		}
+		$logging = new Logging( self::$config );
+		$logging->log(
+			sprintf( 'Strings::%s resolution failed: %s', $key, $e->getMessage() ),
+			__METHOD__,
+			'error'
+		);
 	}
 }

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -517,30 +517,82 @@ class Strings {
 		// Without an `init()` call the filter has no namespace to attach
 		// to. Return the resolved value without filtering — same English
 		// fallback behavior as if a filter was registered but did nothing.
-		if ( ! self::$config instanceof Config ) {
-			return $value;
+		if ( self::$config instanceof Config ) {
+			/**
+			 * Filter the resolved value of a TrustedLogin SDK string.
+			 *
+			 * Fires AFTER override and default fallback so the filter always
+			 * sees the final candidate, regardless of which layer produced it.
+			 *
+			 * @since 1.11.0
+			 *
+			 * @param string $value   The resolved string.
+			 * @param string $key     The {@see Strings} constant being resolved.
+			 * @param array  $context Positional args if any (e.g. count for plurals).
+			 * @param Config $config  Active configuration.
+			 */
+			$value = (string) apply_filters(
+				'trustedlogin/' . self::$config->ns() . '/strings/' . $key,
+				$value,
+				$key,
+				$context,
+				self::$config
+			);
 		}
 
-		/**
-		 * Filter the resolved value of a TrustedLogin SDK string.
-		 *
-		 * Fires AFTER override and default fallback so the filter always
-		 * sees the final candidate, regardless of which layer produced it.
-		 *
-		 * @since 1.11.0
-		 *
-		 * @param string $value   The resolved string.
-		 * @param string $key     The {@see Strings} constant being resolved.
-		 * @param array  $context Positional args if any (e.g. count for plurals).
-		 * @param Config $config  Active configuration.
-		 */
-		return (string) apply_filters(
-			'trustedlogin/' . self::$config->ns() . '/strings/' . $key,
-			$value,
-			$key,
-			$context,
-			self::$config
-		);
+		// Runtime sprintf safety net.
+		//
+		// Static-string overrides are placeholder-validated at Config-
+		// load time, but closures (which return arbitrary strings) and
+		// the runtime filter (which can mutate $value to anything) both
+		// bypass that gate. If their result has MORE placeholders than
+		// the SDK call site is about to sprintf into, PHP 8 throws
+		// ValueError "Too few arguments" — an uncaught fatal that
+		// blows up the consent screen on the customer's site.
+		//
+		// Defense: count placeholders in the resolved value. If it
+		// exceeds the registry-declared count, fall back to a fresh
+		// translation of the default — which we know has exactly the
+		// expected placeholder count because every SDK call site is
+		// hand-authored against it.
+		$registry = self::registry();
+		if ( isset( $registry[ $key ]['placeholders'] ) ) {
+			$expected = (int) $registry[ $key ]['placeholders'];
+			if ( self::count_placeholders( $value ) > $expected ) {
+				return (string) translate( (string) $default, self::$textdomain );
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Count sprintf-style placeholders in a string. Escaped percents
+	 * (`%%`) are not counted. Recognizes positional form (`%1$s`),
+	 * flag/width/precision modifiers (`%05d`, `%.2f`, `%-10s`), and
+	 * all standard conversion types.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param mixed $s
+	 *
+	 * @return int Number of distinct args the string consumes.
+	 */
+	public static function count_placeholders( $s ) {
+		if ( ! is_string( $s ) ) {
+			return 0;
+		}
+		$stripped = str_replace( '%%', '', $s );
+		preg_match_all( '/%(?:\d+\$)?[+\-0-9.\']*[a-zA-Z]/', $stripped, $m );
+		$simple = count( $m[0] );
+
+		// Positional placeholders may reuse slots — `%1$s ... %1$s`
+		// only needs 1 arg, but %1$s + %3$s needs 3 args even with
+		// %2$s missing. Count by max positional index.
+		preg_match_all( '/%(\d+)\$/', $stripped, $pm );
+		$max_pos = empty( $pm[1] ) ? 0 : max( array_map( 'intval', $pm[1] ) );
+
+		return max( $simple, $max_pos );
 	}
 
 	/**

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Translatable strings + integrator overrides.
+ *
+ * The SDK has user-facing strings — consent screen labels, error banners,
+ * post-redirect messages, branding. Integrators want to:
+ *
+ *   1. Localize them (German customer site → German consent screen).
+ *   2. Re-brand them ("Acme Support" instead of "TrustedLogin").
+ *
+ * Two parts to the design:
+ *
+ * - {@see Strings::get()} at every call site, with the SDK's English
+ *   default passed in as a literal so `wp i18n make-pot` extracts it
+ *   for the SDK's own translation pipeline.
+ *
+ * - {@see Strings::load_translations()}, called once by the integrator
+ *   on `plugins_loaded` or `init`. Routes the SDK's bundled `.mo` files
+ *   through the integrator's own textdomain. Strauss-safe by design:
+ *   each integrator's prefixed SDK image loads under a different
+ *   textdomain, so no cross-plugin collision.
+ *
+ * @package TrustedLogin\Client
+ */
+
+namespace TrustedLogin;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @since 1.11.0
+ */
+class Strings {
+
+	// -----------------------------------------------------------------
+	//  Public contract: every overrideable string gets a constant here.
+	//  Constants are stable across versions (renames are breaking).
+	// -----------------------------------------------------------------
+
+	const SECURED_BY                     = 'secured_by';
+	const REVOKE_ACCESS_BUTTON           = 'revoke_access_button';
+	const SUPPORT_TEMPORARILY_UNAVAILABLE = 'support_temporarily_unavailable';
+	const TRY_RECONNECTING               = 'try_reconnecting';
+	const CREATED_TIME_AGO               = 'created_time_ago';
+
+	/**
+	 * Textdomain that runtime translation lookups should hit. Set by
+	 * {@see self::load_translations()}; defaults to the SDK's own
+	 * textdomain (which under Strauss usage will simply be unloaded
+	 * and yield English fallbacks — that's fine).
+	 *
+	 * @var string
+	 */
+	private static $textdomain = 'trustedlogin';
+
+	/**
+	 * @var bool Has the integrator opted in to loading bundled translations?
+	 */
+	private static $translations_loaded = false;
+
+	/**
+	 * @var Config
+	 */
+	private $config;
+
+	/**
+	 * @var array<string, string|callable> Validated overrides keyed by constant value.
+	 */
+	private $overrides;
+
+	/**
+	 * @param Config $config
+	 */
+	public function __construct( Config $config ) {
+		$this->config    = $config;
+		$this->overrides = (array) $config->get_setting( 'strings', array() );
+	}
+
+	// -----------------------------------------------------------------
+	//  Registry — declared shape of every overrideable key. Used by
+	//  Config::validate_strings() to reject malformed overrides before
+	//  they reach sprintf.
+	// -----------------------------------------------------------------
+
+	/**
+	 * @return array<string, array{placeholders:int}>
+	 *
+	 * `placeholders`: how many positional sprintf args the default
+	 * requires. 0 = no placeholders, override is taken verbatim.
+	 * 1+ = override MUST resolve to the same number of placeholders
+	 * (validated behaviorally — see {@see Config::placeholders_safe()}).
+	 */
+	public static function registry() {
+		return array(
+			self::SECURED_BY                      => array( 'placeholders' => 0 ),
+			self::REVOKE_ACCESS_BUTTON            => array( 'placeholders' => 0 ),
+			self::SUPPORT_TEMPORARILY_UNAVAILABLE => array( 'placeholders' => 0 ),
+			self::TRY_RECONNECTING                => array( 'placeholders' => 0 ),
+			self::CREATED_TIME_AGO                => array( 'placeholders' => 2 ),
+		);
+	}
+
+	/**
+	 * The full list of overrideable keys. Convenience for validation.
+	 *
+	 * @return string[]
+	 */
+	public static function known_keys() {
+		return array_keys( self::registry() );
+	}
+
+	// -----------------------------------------------------------------
+	//  Translation loading (integrator opt-in).
+	// -----------------------------------------------------------------
+
+	/**
+	 * Load the SDK's bundled translations against the integrator's textdomain.
+	 *
+	 * Call once from `plugins_loaded` or `init` in your plugin:
+	 *
+	 *     add_action( 'init', function () {
+	 *         \Acme\Vendor\TrustedLogin\Strings::load_translations( 'acme-plugin' );
+	 *     } );
+	 *
+	 * The SDK ships `.mo` files in `src/languages/`. Routing them through
+	 * YOUR textdomain (which Strauss renamed to your plugin's unique
+	 * prefix at build time) sidesteps the multi-SDK textdomain collision
+	 * that would otherwise occur when two TL-using plugins are active on
+	 * the same site.
+	 *
+	 * Hooked on `change_locale` to reload after `switch_to_locale()` /
+	 * `restore_previous_locale()` — fires for emails, REST, multilingual
+	 * plugins.
+	 *
+	 * Skips silently when called before `init` (WP 6.7+ rule against
+	 * early `__()` calls; we honor it for textdomain loading too).
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $textdomain Your plugin's textdomain.
+	 *
+	 * @return void
+	 */
+	public static function load_translations( $textdomain ) {
+		if ( ! is_string( $textdomain ) || '' === $textdomain ) {
+			return;
+		}
+
+		// WP 6.7+ emits a deprecation notice when translation work
+		// happens before `init`. Defer if we got here too early.
+		if ( ! did_action( 'init' ) ) {
+			add_action(
+				'init',
+				static function () use ( $textdomain ) {
+					self::load_translations( $textdomain );
+				}
+			);
+			return;
+		}
+
+		self::$textdomain = $textdomain;
+
+		$mo = self::mo_path_for( determine_locale() );
+		if ( $mo && is_readable( $mo ) ) {
+			load_textdomain( $textdomain, $mo );
+		}
+
+		if ( ! self::$translations_loaded ) {
+			add_action(
+				'change_locale',
+				static function ( $new_locale ) use ( $textdomain ) {
+					$mo = self::mo_path_for( $new_locale );
+					if ( $mo && is_readable( $mo ) ) {
+						load_textdomain( $textdomain, $mo );
+					}
+				}
+			);
+			self::$translations_loaded = true;
+		}
+	}
+
+	/**
+	 * Absolute path to the bundled `.mo` for a locale, or empty string if missing.
+	 *
+	 * Uses `dirname( __FILE__ )` so the path resolves correctly whether
+	 * the SDK is at `wp-content/plugins/foo/vendor_prefixed/trustedlogin/
+	 * client/src/Strings.php` (Strauss layout) or anywhere else.
+	 *
+	 * @param string $locale
+	 *
+	 * @return string
+	 */
+	private static function mo_path_for( $locale ) {
+		if ( ! is_string( $locale ) || '' === $locale ) {
+			return '';
+		}
+		return dirname( __FILE__ ) . '/languages/trustedlogin-' . $locale . '.mo';
+	}
+
+	// -----------------------------------------------------------------
+	//  Translation accessor (called by SDK internals).
+	// -----------------------------------------------------------------
+
+	/**
+	 * Resolve a translatable string by key, falling back to the SDK
+	 * default and finally applying the runtime override filter.
+	 *
+	 * The call site passes the SDK's English default as a LITERAL
+	 * `__()` / `_n()` call wrapped in this getter:
+	 *
+	 *     $label = $strings->get(
+	 *         Strings::SECURED_BY,
+	 *         __( 'Secured by TrustedLogin', 'trustedlogin' )
+	 *     );
+	 *
+	 * Two things happen here:
+	 *
+	 * 1. The literal `__( 'Secured…', 'trustedlogin' )` is the anchor
+	 *    that `wp i18n make-pot` extracts into the SDK's `.pot`. At
+	 *    runtime it returns the input verbatim unless something has
+	 *    explicitly loaded the `trustedlogin` textdomain (which
+	 *    Strauss-prefixed deployments will not).
+	 *
+	 * 2. {@see self::get()} re-translates against the textdomain the
+	 *    integrator passed to {@see self::load_translations()}. That
+	 *    textdomain has the SDK's bundled `.mo` files attached, so the
+	 *    German translation of "Secured by TrustedLogin" comes back
+	 *    here even though the call-site `__()` returned English.
+	 *
+	 * Override resolution (preempts both translations):
+	 *
+	 *   - `null` (no entry)       → return translated $default
+	 *   - `''`   (explicit empty) → return ''
+	 *   - string                  → return the override verbatim
+	 *   - callable($context_vals) → invoke and return its result
+	 *
+	 * The filter `trustedlogin/{namespace}/strings/{key}` fires AFTER
+	 * the override decision so it always sees the final candidate.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param string $key      A {@see self} class constant.
+	 * @param string $default  The SDK's English default. Already translated
+	 *                         by the caller's literal `__()`/`_n()` call.
+	 * @param array  $context  Positional args passed to a closure override
+	 *                         (e.g. `array( $count )` for a plural).
+	 *
+	 * @return string
+	 */
+	public function get( $key, $default, array $context = array() ) {
+		$value = $this->resolve( $key, $default, $context );
+
+		/**
+		 * Filter the resolved value of a TrustedLogin SDK string.
+		 *
+		 * Fires AFTER override and default fallback so the filter always
+		 * sees the final candidate, regardless of which layer produced it.
+		 *
+		 * @since 1.11.0
+		 *
+		 * @param string $value   The resolved string.
+		 * @param string $key     The {@see Strings} constant being resolved.
+		 * @param array  $context Positional args if any (e.g. count for plurals).
+		 * @param Config $config  Active configuration.
+		 */
+		return (string) apply_filters(
+			'trustedlogin/' . $this->config->ns() . '/strings/' . $key,
+			$value,
+			$key,
+			$context,
+			$this->config
+		);
+	}
+
+	/**
+	 * @param string $key
+	 * @param string $default
+	 * @param array  $context
+	 *
+	 * @return string
+	 */
+	private function resolve( $key, $default, array $context ) {
+		if ( array_key_exists( $key, $this->overrides ) ) {
+			$override = $this->overrides[ $key ];
+
+			if ( '' === $override ) {
+				return '';
+			}
+
+			if ( is_string( $override ) ) {
+				return $override;
+			}
+
+			if ( is_callable( $override ) ) {
+				return (string) call_user_func_array( $override, array_values( $context ) );
+			}
+
+			// Shape mismatch should have been caught by Config::validate_strings().
+			// Belt-and-suspenders fallback to default.
+		}
+
+		// No override (or malformed). Translate the SDK's English default
+		// against whichever textdomain the integrator routed our `.mo`
+		// files through. When no `.mo` is loaded under that domain,
+		// translate() returns the input verbatim — English fallback.
+		return (string) translate( (string) $default, self::$textdomain );
+	}
+}

--- a/src/SupportRole.php
+++ b/src/SupportRole.php
@@ -34,11 +34,6 @@ final class SupportRole {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Logging instance.
 	 *
 	 * @var Logging $logging
@@ -101,7 +96,6 @@ final class SupportRole {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config    = $config;
-		$this->strings = new Strings( $config );
 		$this->logging   = $logging;
 		$this->role_name = $this->set_name();
 	}
@@ -279,7 +273,7 @@ final class SupportRole {
 		$role_display_name = apply_filters(
 			'trustedlogin/' . $this->config->ns() . '/support_role/display_name',
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			sprintf( esc_html( $this->strings->get( Strings::S_SUPPORT, __( '%s Support', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) ),
+			sprintf( esc_html( Strings::get( Strings::S_SUPPORT, __( '%s Support', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) ),
 			$this
 		);
 

--- a/src/SupportRole.php
+++ b/src/SupportRole.php
@@ -34,6 +34,11 @@ final class SupportRole {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Logging instance.
 	 *
 	 * @var Logging $logging
@@ -96,6 +101,7 @@ final class SupportRole {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config    = $config;
+		$this->strings = new Strings( $config );
 		$this->logging   = $logging;
 		$this->role_name = $this->set_name();
 	}
@@ -273,7 +279,7 @@ final class SupportRole {
 		$role_display_name = apply_filters(
 			'trustedlogin/' . $this->config->ns() . '/support_role/display_name',
 			// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-			sprintf( esc_html__( '%s Support', 'trustedlogin' ), $this->config->get_setting( 'vendor/title' ) ),
+			sprintf( esc_html( $this->strings->get( Strings::S_SUPPORT, __( '%s Support', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) ),
 			$this
 		);
 

--- a/src/SupportUser.php
+++ b/src/SupportUser.php
@@ -245,11 +245,9 @@ final class SupportUser {
 			'user_registered' => gmdate( 'Y-m-d H:i:s' ),
 		);
 
-		// Optional locale for the support user. Setting it via
-		// wp_insert_user's `locale` arg (stable since WP 4.7) ensures
-		// the welcome email + first-render of wp-admin both honor it —
-		// a post-create update_user_meta() runs after those have
-		// already fired with the site default locale.
+		// Setting `locale` via wp_insert_user args (vs. a post-create
+		// update_user_meta) ensures the welcome email + first wp-admin
+		// render honor it. Stable since WP 4.7.
 		$locale = $this->resolve_support_user_locale();
 		if ( '' !== $locale ) {
 			$user_data['locale'] = $locale;
@@ -263,9 +261,7 @@ final class SupportUser {
 			return $new_user_id;
 		}
 
-		// Defensive re-assert in case a `wp_pre_insert_user_data` filter
-		// (e.g. a security plugin stripping unknown fields) dropped the
-		// locale before wp_insert_user wrote it.
+		// Re-assert in case a `wp_pre_insert_user_data` filter dropped it.
 		if ( '' !== $locale && get_user_meta( $new_user_id, 'locale', true ) !== $locale ) {
 			update_user_meta( $new_user_id, 'locale', $locale );
 		}
@@ -278,10 +274,10 @@ final class SupportUser {
 	/**
 	 * Resolve the locale to assign to a newly created support user.
 	 *
-	 * Reads `support_user/locale` from Config, runs through a
-	 * namespaced filter, then format-checks. Returns an empty string
-	 * when no locale is requested or the requested locale fails the
-	 * format check — letting WordPress fall back to the site default.
+	 * Reads `support_user/locale` from Config, runs through the
+	 * `trustedlogin/{namespace}/support_user/locale` filter, and
+	 * format-checks. Returns an empty string for "no locale set" —
+	 * WordPress then falls back to the site default.
 	 *
 	 * @since 1.11.0
 	 *
@@ -309,10 +305,7 @@ final class SupportUser {
 			return '';
 		}
 
-		// Format-only validation. Covers `de_DE`, `pt_BR`, `de_DE_formal`,
-		// `pt_PT_ao90` (digits in variant), `cmn` / `ckb` (3-letter language
-		// codes). Variant is nested INSIDE the region group so `de_de`
-		// doesn't slip through as "lang + variant".
+		// Variant nested inside region so `de_de` doesn't parse as "lang + variant".
 		if ( ! preg_match( '/^[a-z]{2,3}(_[A-Z]{2}(_[a-z0-9]+)?)?$/', $locale ) ) {
 			$this->logging->log(
 				'Ignoring malformed support_user/locale setting: ' . esc_attr( $locale ),

--- a/src/SupportUser.php
+++ b/src/SupportUser.php
@@ -39,6 +39,11 @@ final class SupportUser {
 	private $config;
 
 	/**
+	 * @var Strings
+	 */
+	private $strings;
+
+	/**
 	 * Logging instance.
 	 *
 	 * @var Logging $logging
@@ -95,6 +100,7 @@ final class SupportUser {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config  = $config;
+		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 		$this->role    = new SupportRole( $config, $logging );
 
@@ -229,7 +235,7 @@ final class SupportUser {
 			// Only allow the user to be created if the email is not hashed; that way, it's not possible to accidentally
 			// create a user with the same email as an existing user.
 			if ( ! $allow_existing_user_match ) {
-				return new \WP_Error( 'email_exists', esc_html__( 'User not created; User with that email already exists', 'trustedlogin' ) );
+				return new \WP_Error( 'email_exists', esc_html( $this->strings->get( Strings::USER_NOT_CREATED_USER_WITH_THAT, __( 'User not created; User with that email already exists', 'trustedlogin' ) ) ) );
 			}
 
 			// If the user already exists and the email matches the hash, use that user.
@@ -283,19 +289,6 @@ final class SupportUser {
 	 * when no locale is requested or the requested locale fails the
 	 * format check — letting WordPress fall back to the site default.
 	 *
-	 * Deliberately does NOT gate on `get_available_languages()`:
-	 *
-	 *   - It excludes `en_US` (the default is always available but
-	 *     never listed), so checking against it silently rejects a
-	 *     legitimate value.
-	 *   - It misses WPML / Polylang custom locales.
-	 *   - It misses translations bundled by other plugins under their
-	 *     own paths.
-	 *
-	 * WordPress's translation machinery already falls back to English
-	 * for any locale whose `.mo` files aren't installed, so a format-
-	 * only gate is both safer and more inclusive.
-	 *
 	 * @since 1.11.0
 	 *
 	 * @return string Locale code, or empty string for "site default".
@@ -323,11 +316,9 @@ final class SupportUser {
 		}
 
 		// Format-only validation. Covers `de_DE`, `pt_BR`, `de_DE_formal`,
-		// `pt_PT_ao90` (digits in variant — real WP.org locale), `cmn` /
-		// `ckb` (3-letter language codes). Rejects obvious garbage so a
-		// typo doesn't get written to wp_usermeta. The variant suffix
-		// is nested INSIDE the region group so a malformed
-		// "lang_lowercase" doesn't slip through as "lang + variant".
+		// `pt_PT_ao90` (digits in variant), `cmn` / `ckb` (3-letter language
+		// codes). Variant is nested INSIDE the region group so `de_de`
+		// doesn't slip through as "lang + variant".
 		if ( ! preg_match( '/^[a-z]{2,3}(_[A-Z]{2}(_[a-z0-9]+)?)?$/', $locale ) ) {
 			$this->logging->log(
 				'Ignoring malformed support_user/locale setting: ' . esc_attr( $locale ),
@@ -348,7 +339,7 @@ final class SupportUser {
 	private function generate_unique_username() {
 
 		// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-		$username = sprintf( esc_html__( '%s Support', 'trustedlogin' ), $this->config->get_setting( 'vendor/title' ) );
+		$username = sprintf( esc_html( $this->strings->get( Strings::S_SUPPORT, __( '%s Support', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) );
 
 		if ( ! username_exists( $username ) ) {
 			return $username;

--- a/src/SupportUser.php
+++ b/src/SupportUser.php
@@ -39,11 +39,6 @@ final class SupportUser {
 	private $config;
 
 	/**
-	 * @var Strings
-	 */
-	private $strings;
-
-	/**
 	 * Logging instance.
 	 *
 	 * @var Logging $logging
@@ -100,7 +95,6 @@ final class SupportUser {
 	 */
 	public function __construct( Config $config, Logging $logging ) {
 		$this->config  = $config;
-		$this->strings = new Strings( $config );
 		$this->logging = $logging;
 		$this->role    = new SupportRole( $config, $logging );
 
@@ -235,7 +229,7 @@ final class SupportUser {
 			// Only allow the user to be created if the email is not hashed; that way, it's not possible to accidentally
 			// create a user with the same email as an existing user.
 			if ( ! $allow_existing_user_match ) {
-				return new \WP_Error( 'email_exists', esc_html( $this->strings->get( Strings::USER_NOT_CREATED_USER_WITH_THAT, __( 'User not created; User with that email already exists', 'trustedlogin' ) ) ) );
+				return new \WP_Error( 'email_exists', esc_html( Strings::get( Strings::USER_NOT_CREATED_USER_WITH_THAT, __( 'User not created; User with that email already exists', 'trustedlogin' ) ) ) );
 			}
 
 			// If the user already exists and the email matches the hash, use that user.
@@ -339,7 +333,7 @@ final class SupportUser {
 	private function generate_unique_username() {
 
 		// translators: %s is replaced with the name of the software developer (e.g. "Acme Widgets").
-		$username = sprintf( esc_html( $this->strings->get( Strings::S_SUPPORT, __( '%s Support', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) );
+		$username = sprintf( esc_html( Strings::get( Strings::S_SUPPORT, __( '%s Support', 'trustedlogin' ) ) ), $this->config->get_setting( 'vendor/title' ) );
 
 		if ( ! username_exists( $username ) ) {
 			return $username;

--- a/src/SupportUser.php
+++ b/src/SupportUser.php
@@ -245,6 +245,16 @@ final class SupportUser {
 			'user_registered' => gmdate( 'Y-m-d H:i:s' ),
 		);
 
+		// Optional locale for the support user. Setting it via
+		// wp_insert_user's `locale` arg (stable since WP 4.7) ensures
+		// the welcome email + first-render of wp-admin both honor it —
+		// a post-create update_user_meta() runs after those have
+		// already fired with the site default locale.
+		$locale = $this->resolve_support_user_locale();
+		if ( '' !== $locale ) {
+			$user_data['locale'] = $locale;
+		}
+
 		$new_user_id = wp_insert_user( $user_data );
 
 		if ( is_wp_error( $new_user_id ) ) {
@@ -253,9 +263,81 @@ final class SupportUser {
 			return $new_user_id;
 		}
 
+		// Defensive re-assert in case a `wp_pre_insert_user_data` filter
+		// (e.g. a security plugin stripping unknown fields) dropped the
+		// locale before wp_insert_user wrote it.
+		if ( '' !== $locale && get_user_meta( $new_user_id, 'locale', true ) !== $locale ) {
+			update_user_meta( $new_user_id, 'locale', $locale );
+		}
+
 		$this->logging->log( 'Support User #' . $new_user_id, __METHOD__, 'info' );
 
 		return $new_user_id;
+	}
+
+	/**
+	 * Resolve the locale to assign to a newly created support user.
+	 *
+	 * Reads `support_user/locale` from Config, runs through a
+	 * namespaced filter, then format-checks. Returns an empty string
+	 * when no locale is requested or the requested locale fails the
+	 * format check — letting WordPress fall back to the site default.
+	 *
+	 * Deliberately does NOT gate on `get_available_languages()`:
+	 *
+	 *   - It excludes `en_US` (the default is always available but
+	 *     never listed), so checking against it silently rejects a
+	 *     legitimate value.
+	 *   - It misses WPML / Polylang custom locales.
+	 *   - It misses translations bundled by other plugins under their
+	 *     own paths.
+	 *
+	 * WordPress's translation machinery already falls back to English
+	 * for any locale whose `.mo` files aren't installed, so a format-
+	 * only gate is both safer and more inclusive.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @return string Locale code, or empty string for "site default".
+	 */
+	private function resolve_support_user_locale() {
+
+		$configured = (string) $this->config->get_setting( 'support_user/locale', '' );
+
+		/**
+		 * Filter the locale assigned to a newly created support user.
+		 *
+		 * @since 1.11.0
+		 *
+		 * @param string $locale Locale code, or '' for site default.
+		 * @param Config $config Active configuration.
+		 */
+		$locale = (string) apply_filters(
+			'trustedlogin/' . $this->config->ns() . '/support_user/locale',
+			$configured,
+			$this->config
+		);
+
+		if ( '' === $locale ) {
+			return '';
+		}
+
+		// Format-only validation. Covers `de_DE`, `pt_BR`, `de_DE_formal`,
+		// `pt_PT_ao90` (digits in variant — real WP.org locale), `cmn` /
+		// `ckb` (3-letter language codes). Rejects obvious garbage so a
+		// typo doesn't get written to wp_usermeta. The variant suffix
+		// is nested INSIDE the region group so a malformed
+		// "lang_lowercase" doesn't slip through as "lang + variant".
+		if ( ! preg_match( '/^[a-z]{2,3}(_[A-Z]{2}(_[a-z0-9]+)?)?$/', $locale ) ) {
+			$this->logging->log(
+				'Ignoring malformed support_user/locale setting: ' . esc_attr( $locale ),
+				__METHOD__,
+				'warning'
+			);
+			return '';
+		}
+
+		return $locale;
 	}
 
 	/**

--- a/tests/test-strings-translation.php
+++ b/tests/test-strings-translation.php
@@ -38,20 +38,12 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Reset Strings' static $textdomain and $translations_loaded so
-	 * tests don't leak state through each other. The runtime textdomain
-	 * is private-static, so we poke it via reflection.
+	 * Reset Strings' static state so tests don't leak through each other.
+	 * Strings::reset() clears $config, $overrides, $textdomain, and
+	 * $translations_loaded in one shot.
 	 */
 	private function reset_strings_state(): void {
-		$rc = new \ReflectionClass( Strings::class );
-
-		$domain = $rc->getProperty( 'textdomain' );
-		$domain->setAccessible( true );
-		$domain->setValue( null, 'trustedlogin' );
-
-		$loaded = $rc->getProperty( 'translations_loaded' );
-		$loaded->setAccessible( true );
-		$loaded->setValue( null, false );
+		Strings::reset();
 	}
 
 	private function build_config( array $overrides = array() ): Config {
@@ -127,10 +119,10 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 
 		Strings::load_translations( 'acme-plugin' );
 
-		$strings = new Strings( $this->build_config() );
+		Strings::init( $this->build_config() );
 		$this->assertSame(
 			'Abgesichert durch Acme Support',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -138,10 +130,10 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		// No load_translations() call — runtime textdomain stays
 		// 'trustedlogin', which has no translations registered. The
 		// SDK's English default flows through.
-		$strings = new Strings( $this->build_config() );
+		Strings::init( $this->build_config() );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -180,10 +172,10 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		switch_to_locale( 'fr_FR' );
 
 		try {
-			$strings = new Strings( $this->build_config() );
+			Strings::init( $this->build_config() );
 			$this->assertSame(
 				'Réessayer la connexion',
-				$strings->get( Strings::TRY_RECONNECTING, __( 'Try reconnecting', 'trustedlogin' ) )
+				Strings::get( Strings::TRY_RECONNECTING, __( 'Try reconnecting', 'trustedlogin' ) )
 			);
 		} finally {
 			restore_previous_locale();
@@ -204,12 +196,12 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		$config = $this->build_config( array(
 			Strings::SECURED_BY_TRUSTEDLOGIN => 'Powered by Acme', // verbatim brand
 		) );
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 
 		// Override wins. Translation never runs for this key.
 		$this->assertSame(
 			'Powered by Acme',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -230,8 +222,8 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 			},
 		) );
 
-		$strings  = new Strings( $config );
-		$resolved = $strings->get(
+		Strings::init( $config  );
+		$resolved = Strings::get(
 			Strings::CREATED_1_S_AGO_BY_2,
 			'Created %1$s ago by %2$s',
 			array( '5 minutes', 'admin' )
@@ -250,7 +242,7 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 
 		try {
 			$config  = $this->build_config();
-			$strings = new Strings( $config );
+			Strings::init( $config  );
 
 			$tag = 'trustedlogin/translation-test/strings/' . Strings::TRY_RECONNECTING;
 
@@ -264,7 +256,7 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 			try {
 				$this->assertSame(
 					'Erneut verbinden',
-					$strings->get( Strings::TRY_RECONNECTING, 'Try reconnecting' )
+					Strings::get( Strings::TRY_RECONNECTING, 'Try reconnecting' )
 				);
 			} finally {
 				remove_filter( $tag, $contextual, 10 );

--- a/tests/test-strings-translation.php
+++ b/tests/test-strings-translation.php
@@ -290,4 +290,103 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		$this->assertSame( 'acme-plugin', $rc->getValue( null ),
 			'After init, load should run immediately.' );
 	}
+
+	// =================================================================
+	//  Coverage gaps from the audit pass
+	// =================================================================
+
+	public function test_repeated_load_translations_registers_change_locale_once() {
+		// Count change_locale callbacks at priority 10 before & after.
+		global $wp_filter;
+		$before = isset( $wp_filter['change_locale'] )
+			? count( $wp_filter['change_locale']->callbacks[10] ?? array() )
+			: 0;
+
+		Strings::load_translations( 'acme-plugin' );
+		Strings::load_translations( 'other-plugin' );
+		Strings::load_translations( 'third-plugin' );
+
+		$after = count( $wp_filter['change_locale']->callbacks[10] );
+		$this->assertSame( $before + 1, $after,
+			'Repeated load_translations calls must add exactly one change_locale callback total.' );
+	}
+
+	public function test_second_load_translations_overrides_textdomain() {
+		Strings::load_translations( 'acme-plugin' );
+		Strings::load_translations( 'beta-plugin' );
+
+		$rc = new ReflectionProperty( Strings::class, 'textdomain' );
+		$rc->setAccessible( true );
+		$this->assertSame( 'beta-plugin', $rc->getValue( null ),
+			'The most recent load_translations call wins.' );
+	}
+
+	public function test_change_locale_callback_reads_latest_textdomain_after_second_load() {
+		// The closure's load_textdomain() call is gated on
+		// is_readable() of the .mo path, so we need a real file at
+		// that location to make the spy fire. Build a 0-byte placeholder.
+		$rc          = new \ReflectionClass( Strings::class );
+		$languages   = dirname( $rc->getFileName() ) . '/languages';
+		if ( ! is_dir( $languages ) ) {
+			mkdir( $languages, 0755, true );
+		}
+		$fake_mo = $languages . '/trustedlogin-fr_FR.mo';
+		file_put_contents( $fake_mo, '' );
+		$this->cleanups[] = static function () use ( $fake_mo, $languages ) {
+			if ( is_file( $fake_mo ) ) {
+				unlink( $fake_mo );
+			}
+			// Best-effort dir cleanup; ignore if not empty.
+			@rmdir( $languages );
+		};
+
+		$attempts = array();
+		$spy      = static function ( $override, $domain ) use ( &$attempts ) {
+			unset( $override );
+			$attempts[] = $domain;
+			return true;
+		};
+		add_filter( 'override_load_textdomain', $spy, 10, 2 );
+
+		try {
+			Strings::load_translations( 'acme-plugin' );
+			Strings::load_translations( 'beta-plugin' );
+			$attempts = array(); // ignore the immediate loads
+
+			do_action( 'change_locale', 'fr_FR' );
+
+			$this->assertContains( 'beta-plugin', $attempts,
+				'change_locale must load .mo against the LATEST textdomain, not the captured-at-registration one.' );
+			$this->assertNotContains( 'acme-plugin', $attempts,
+				'Stale textdomain must NOT be referenced after second load.' );
+		} finally {
+			remove_filter( 'override_load_textdomain', $spy, 10 );
+		}
+	}
+
+	public function test_mo_path_resolves_relative_to_strings_file() {
+		// mo_path_for is private; reach via reflection. The path must
+		// be anchored to the Strings.php directory (so Strauss-vendored
+		// layouts resolve correctly), NOT to WP_PLUGIN_DIR.
+		$rc     = new \ReflectionClass( Strings::class );
+		$method = $rc->getMethod( 'mo_path_for' );
+		$method->setAccessible( true );
+
+		$path = $method->invoke( null, 'de_DE' );
+		$strings_dir = dirname( $rc->getFileName() );
+
+		$this->assertSame(
+			$strings_dir . '/languages/trustedlogin-de_DE.mo',
+			$path,
+			'mo_path_for must be relative to the Strings.php source file.'
+		);
+	}
+
+	public function test_load_translations_with_non_string_argument_is_noop() {
+		Strings::load_translations( '' );
+
+		$rc = new ReflectionProperty( Strings::class, 'textdomain' );
+		$rc->setAccessible( true );
+		$this->assertSame( 'trustedlogin', $rc->getValue( null ) );
+	}
 }

--- a/tests/test-strings-translation.php
+++ b/tests/test-strings-translation.php
@@ -130,7 +130,7 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		$strings = new Strings( $this->build_config() );
 		$this->assertSame(
 			'Abgesichert durch Acme Support',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -141,7 +141,7 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		$strings = new Strings( $this->build_config() );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -202,14 +202,14 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		Strings::load_translations( 'acme-plugin' );
 
 		$config = $this->build_config( array(
-			Strings::SECURED_BY => 'Powered by Acme', // verbatim brand
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'Powered by Acme', // verbatim brand
 		) );
 		$strings = new Strings( $config );
 
 		// Override wins. Translation never runs for this key.
 		$this->assertSame(
 			'Powered by Acme',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -221,7 +221,7 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		) );
 
 		$config = $this->build_config( array(
-			Strings::CREATED_TIME_AGO => static function ( $time_ago, $by ) {
+			Strings::CREATED_1_S_AGO_BY_2 => static function ( $time_ago, $by ) {
 				// The integrator does whatever they want here. They
 				// could call _n(), __(), sprintf(), pull from a
 				// database — the SDK doesn't care.
@@ -232,7 +232,7 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 
 		$strings  = new Strings( $config );
 		$resolved = $strings->get(
-			Strings::CREATED_TIME_AGO,
+			Strings::CREATED_1_S_AGO_BY_2,
 			'Created %1$s ago by %2$s',
 			array( '5 minutes', 'admin' )
 		);

--- a/tests/test-strings-translation.php
+++ b/tests/test-strings-translation.php
@@ -83,9 +83,6 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		};
 	}
 
-	// =================================================================
-	//  load_translations() runtime behavior
-	// =================================================================
 
 	public function test_default_runtime_textdomain_is_trustedlogin() {
 		$rc       = new ReflectionProperty( Strings::class, 'textdomain' );
@@ -137,9 +134,6 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		);
 	}
 
-	// =================================================================
-	//  change_locale hook reloads under switch_to_locale()
-	// =================================================================
 
 	public function test_load_translations_registers_change_locale_hook() {
 		Strings::load_translations( 'acme-plugin' );
@@ -182,9 +176,6 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		}
 	}
 
-	// =================================================================
-	//  Override + translation interaction
-	// =================================================================
 
 	public function test_static_override_preempts_translation() {
 		$this->inject_translation( 'acme-plugin', array(
@@ -266,9 +257,6 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 		}
 	}
 
-	// =================================================================
-	//  Hook timing: load_translations() before init defers safely
-	// =================================================================
 
 	public function test_load_translations_before_init_defers() {
 		// We can't actually un-fire `init` once it's done in the test
@@ -291,9 +279,6 @@ class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
 			'After init, load should run immediately.' );
 	}
 
-	// =================================================================
-	//  Coverage gaps from the audit pass
-	// =================================================================
 
 	public function test_repeated_load_translations_registers_change_locale_once() {
 		// Count change_locale callbacks at priority 10 before & after.

--- a/tests/test-strings-translation.php
+++ b/tests/test-strings-translation.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Strings translation routing — load_translations(), runtime textdomain
+ * lookup, change_locale reload, closure overrides under user-locale
+ * context.
+ *
+ * These tests use `add_filter('gettext_with_context', …)` and
+ * `add_filter('gettext', …)` to inject fake translations into WP's
+ * lookup pipeline without producing real `.mo` files. The same pipeline
+ * Strings::get() consults via translate(), so what the filter returns
+ * is what the SDK sees at runtime.
+ *
+ * @package TrustedLogin\Client
+ */
+
+namespace TrustedLogin;
+
+use WP_UnitTestCase;
+use ReflectionProperty;
+
+class TrustedLoginStringsTranslationTest extends WP_UnitTestCase {
+
+	/** @var callable[] Cleanup callbacks queued during a test. */
+	private $cleanups = array();
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->reset_strings_state();
+	}
+
+	public function tearDown(): void {
+		foreach ( $this->cleanups as $cleanup ) {
+			$cleanup();
+		}
+		$this->cleanups = array();
+		$this->reset_strings_state();
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset Strings' static $textdomain and $translations_loaded so
+	 * tests don't leak state through each other. The runtime textdomain
+	 * is private-static, so we poke it via reflection.
+	 */
+	private function reset_strings_state(): void {
+		$rc = new \ReflectionClass( Strings::class );
+
+		$domain = $rc->getProperty( 'textdomain' );
+		$domain->setAccessible( true );
+		$domain->setValue( null, 'trustedlogin' );
+
+		$loaded = $rc->getProperty( 'translations_loaded' );
+		$loaded->setAccessible( true );
+		$loaded->setValue( null, false );
+	}
+
+	private function build_config( array $overrides = array() ): Config {
+		$base = array(
+			'auth'   => array( 'api_key' => '9946ca31be6aa948' ),
+			'vendor' => array(
+				'namespace'   => 'translation-test',
+				'title'       => 'Translation Test',
+				'email'       => 'support@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+		);
+		if ( ! empty( $overrides ) ) {
+			$base['strings'] = $overrides;
+		}
+		$config = new Config( $base );
+		$config->validate();
+		return $config;
+	}
+
+	/**
+	 * Inject a fake translation pair (msgid → msgstr) for a specific
+	 * textdomain. The gettext filter runs after WP's own lookup, so
+	 * our return value wins. Queues cleanup automatically.
+	 */
+	private function inject_translation( string $domain, array $pairs ): void {
+		$filter = static function ( $translation, $original, $d ) use ( $domain, $pairs ) {
+			if ( $d === $domain && isset( $pairs[ $original ] ) ) {
+				return $pairs[ $original ];
+			}
+			return $translation;
+		};
+		add_filter( 'gettext', $filter, 10, 3 );
+		$this->cleanups[] = static function () use ( $filter ) {
+			remove_filter( 'gettext', $filter, 10 );
+		};
+	}
+
+	// =================================================================
+	//  load_translations() runtime behavior
+	// =================================================================
+
+	public function test_default_runtime_textdomain_is_trustedlogin() {
+		$rc       = new ReflectionProperty( Strings::class, 'textdomain' );
+		$rc->setAccessible( true );
+		$this->assertSame( 'trustedlogin', $rc->getValue( null ) );
+	}
+
+	public function test_load_translations_sets_runtime_textdomain() {
+		Strings::load_translations( 'acme-plugin' );
+
+		$rc = new ReflectionProperty( Strings::class, 'textdomain' );
+		$rc->setAccessible( true );
+		$this->assertSame( 'acme-plugin', $rc->getValue( null ) );
+	}
+
+	public function test_load_translations_with_empty_string_is_noop() {
+		Strings::load_translations( '' );
+
+		$rc = new ReflectionProperty( Strings::class, 'textdomain' );
+		$rc->setAccessible( true );
+		$this->assertSame( 'trustedlogin', $rc->getValue( null ),
+			'Empty domain must not overwrite the default.' );
+	}
+
+	public function test_load_translations_routes_lookups_to_integrator_textdomain() {
+		// Tell WP that "Secured by TrustedLogin" translates to a German
+		// brand-flavored string in the 'acme-plugin' textdomain.
+		$this->inject_translation( 'acme-plugin', array(
+			'Secured by TrustedLogin' => 'Abgesichert durch Acme Support',
+		) );
+
+		Strings::load_translations( 'acme-plugin' );
+
+		$strings = new Strings( $this->build_config() );
+		$this->assertSame(
+			'Abgesichert durch Acme Support',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	public function test_lookups_against_unloaded_textdomain_return_input() {
+		// No load_translations() call — runtime textdomain stays
+		// 'trustedlogin', which has no translations registered. The
+		// SDK's English default flows through.
+		$strings = new Strings( $this->build_config() );
+		$this->assertSame(
+			'Secured by TrustedLogin',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	// =================================================================
+	//  change_locale hook reloads under switch_to_locale()
+	// =================================================================
+
+	public function test_load_translations_registers_change_locale_hook() {
+		Strings::load_translations( 'acme-plugin' );
+		$this->assertNotFalse( has_action( 'change_locale' ),
+			'A change_locale callback should be registered after load_translations().' );
+	}
+
+	public function test_change_locale_callback_runs_without_mo_file() {
+		// Without a real fr_FR .mo file shipped in src/languages/, the
+		// SDK's mo_path_for() returns a path that isn't readable, so
+		// the callback short-circuits before calling load_textdomain.
+		// The callback running (and not crashing) is the contract under
+		// test here; actual reload behavior with a real .mo is a
+		// release-time concern, not a unit-test one.
+		Strings::load_translations( 'acme-plugin' );
+		do_action( 'change_locale', 'fr_FR' );
+
+		// If we got here without a fatal, the callback handled the
+		// missing-file case gracefully — that's the assertion.
+		$this->addToAssertionCount( 1 );
+	}
+
+	public function test_translations_reload_picks_up_new_locale_messages() {
+		// French translations for the SAME msgid that German didn't cover.
+		$this->inject_translation( 'acme-plugin', array(
+			'Try reconnecting' => 'Réessayer la connexion',
+		) );
+
+		Strings::load_translations( 'acme-plugin' );
+		switch_to_locale( 'fr_FR' );
+
+		try {
+			$strings = new Strings( $this->build_config() );
+			$this->assertSame(
+				'Réessayer la connexion',
+				$strings->get( Strings::TRY_RECONNECTING, __( 'Try reconnecting', 'trustedlogin' ) )
+			);
+		} finally {
+			restore_previous_locale();
+		}
+	}
+
+	// =================================================================
+	//  Override + translation interaction
+	// =================================================================
+
+	public function test_static_override_preempts_translation() {
+		$this->inject_translation( 'acme-plugin', array(
+			'Secured by TrustedLogin' => 'Abgesichert durch Acme',
+		) );
+
+		Strings::load_translations( 'acme-plugin' );
+
+		$config = $this->build_config( array(
+			Strings::SECURED_BY => 'Powered by Acme', // verbatim brand
+		) );
+		$strings = new Strings( $config );
+
+		// Override wins. Translation never runs for this key.
+		$this->assertSame(
+			'Powered by Acme',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	public function test_closure_override_can_invoke_translation_functions() {
+		// The integrator's closure can call __() against their OWN
+		// textdomain. Whatever that returns is what the SDK renders.
+		$this->inject_translation( 'integrator-domain', array(
+			'%d day of Acme support' => '%d Tag Acme-Support',
+		) );
+
+		$config = $this->build_config( array(
+			Strings::CREATED_TIME_AGO => static function ( $time_ago, $by ) {
+				// The integrator does whatever they want here. They
+				// could call _n(), __(), sprintf(), pull from a
+				// database — the SDK doesn't care.
+				$translated = __( '%d day of Acme support', 'integrator-domain' );
+				return sprintf( '%s — %s ago, %s', $translated, $time_ago, $by );
+			},
+		) );
+
+		$strings  = new Strings( $config );
+		$resolved = $strings->get(
+			Strings::CREATED_TIME_AGO,
+			'Created %1$s ago by %2$s',
+			array( '5 minutes', 'admin' )
+		);
+
+		// Closure used the German translation it just looked up.
+		$this->assertStringContainsString( '%d Tag Acme-Support', $resolved );
+		$this->assertStringContainsString( '5 minutes', $resolved );
+		$this->assertStringContainsString( 'admin', $resolved );
+	}
+
+	public function test_runtime_filter_sees_user_locale_for_context_aware_overrides() {
+		// Set up a user-specific locale via switch_to_locale (simpler
+		// than spinning a user fixture and calling switch_to_user_locale).
+		switch_to_locale( 'de_DE' );
+
+		try {
+			$config  = $this->build_config();
+			$strings = new Strings( $config );
+
+			$tag = 'trustedlogin/translation-test/strings/' . Strings::TRY_RECONNECTING;
+
+			$contextual = static function ( $value ) {
+				return determine_locale() === 'de_DE'
+					? 'Erneut verbinden'
+					: $value;
+			};
+			add_filter( $tag, $contextual, 10, 1 );
+
+			try {
+				$this->assertSame(
+					'Erneut verbinden',
+					$strings->get( Strings::TRY_RECONNECTING, 'Try reconnecting' )
+				);
+			} finally {
+				remove_filter( $tag, $contextual, 10 );
+			}
+		} finally {
+			restore_previous_locale();
+		}
+	}
+
+	// =================================================================
+	//  Hook timing: load_translations() before init defers safely
+	// =================================================================
+
+	public function test_load_translations_before_init_defers() {
+		// We can't actually un-fire `init` once it's done in the test
+		// harness (it fires during WP bootstrap). But we can assert the
+		// guard is in place: invocation during a known-pre-init context
+		// produces a queued action rather than an immediate load.
+		// The empirical proof is `did_action('init')` returns 0 inside
+		// some fixture contexts (e.g., constructor of a class loaded
+		// before init). Since the test harness has already fired init,
+		// we just verify the immediate-load path works AND the deferred
+		// path adds an action.
+		$this->assertGreaterThan( 0, did_action( 'init' ),
+			'Test harness should have fired init already.' );
+
+		Strings::load_translations( 'acme-plugin' );
+
+		$rc = new ReflectionProperty( Strings::class, 'textdomain' );
+		$rc->setAccessible( true );
+		$this->assertSame( 'acme-plugin', $rc->getValue( null ),
+			'After init, load should run immediately.' );
+	}
+}

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -39,7 +39,7 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		$strings = new Strings( $this->build_config() );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -49,13 +49,13 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 	public function test_string_override_replaces_default() {
 		$config = $this->build_config( array(
-			Strings::SECURED_BY => 'Powered by Acme Support',
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'Powered by Acme Support',
 		) );
 
 		$strings = new Strings( $config );
 		$this->assertSame(
 			'Powered by Acme Support',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -65,13 +65,13 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 	public function test_explicit_empty_override_renders_empty() {
 		$config = $this->build_config( array(
-			Strings::SECURED_BY => '',
+			Strings::SECURED_BY_TRUSTEDLOGIN => '',
 		) );
 
 		$strings = new Strings( $config );
 		$this->assertSame(
 			'',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -81,14 +81,14 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 	public function test_closure_override_receives_context() {
 		$config = $this->build_config( array(
-			Strings::CREATED_TIME_AGO => static function ( $time_ago, $by ) {
+			Strings::CREATED_1_S_AGO_BY_2 => static function ( $time_ago, $by ) {
 				return "Acme created {$time_ago} ago by {$by}";
 			},
 		) );
 
 		$strings = new Strings( $config );
 		$resolved = $strings->get(
-			Strings::CREATED_TIME_AGO,
+			Strings::CREATED_1_S_AGO_BY_2,
 			'Created %1$s ago by %2$s',
 			array( '5 minutes', 'admin' )
 		);
@@ -106,14 +106,14 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 	public function test_override_with_missing_placeholder_is_discarded() {
 		$config = $this->build_config( array(
-			Strings::CREATED_TIME_AGO => 'Created at unknown time', // no %1$s %2$s
+			Strings::CREATED_1_S_AGO_BY_2 => 'Created at unknown time', // no %1$s %2$s
 		) );
 
 		$strings = new Strings( $config );
 
 		// Override was malformed → discarded → falls through to SDK default.
 		$resolved = $strings->get(
-			Strings::CREATED_TIME_AGO,
+			Strings::CREATED_1_S_AGO_BY_2,
 			'Created %1$s ago by %2$s',
 			array( '5 minutes', 'admin' )
 		);
@@ -128,13 +128,13 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		// SECURED_BY expects 0 placeholders. Override that smuggles
 		// a %d should be dropped — would print "%d" raw to customers.
 		$config = $this->build_config( array(
-			Strings::SECURED_BY => 'Secured by TL (%d sites protected)',
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'Secured by TL (%d sites protected)',
 		) );
 
 		$strings = new Strings( $config );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -142,13 +142,13 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		// `%%` is the literal percent sign — not a real placeholder.
 		// Must pass the safety check.
 		$config = $this->build_config( array(
-			Strings::SECURED_BY => 'Secured by 100%% you',
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'Secured by 100%% you',
 		) );
 
 		$strings = new Strings( $config );
 		$this->assertSame(
 			'Secured by 100%% you',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -176,7 +176,7 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		$config  = $this->build_config();
 		$strings = new Strings( $config );
 
-		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY;
+		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN;
 
 		$rewriter = static function ( $value ) {
 			return strtoupper( $value );
@@ -186,7 +186,7 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		try {
 			$this->assertSame(
 				'SECURED BY TRUSTEDLOGIN',
-				$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+				$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 			);
 		} finally {
 			remove_filter( $tag, $rewriter, 10 );
@@ -199,13 +199,13 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 	public function test_object_override_is_discarded() {
 		$config = $this->build_config( array(
-			Strings::SECURED_BY => new \stdClass(),
+			Strings::SECURED_BY_TRUSTEDLOGIN => new \stdClass(),
 		) );
 
 		$strings = new Strings( $config );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -216,13 +216,13 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 	public function test_registry_includes_every_class_constant() {
 		$registry = Strings::registry();
 
-		$this->assertArrayHasKey( Strings::SECURED_BY, $registry );
-		$this->assertArrayHasKey( Strings::REVOKE_ACCESS_BUTTON, $registry );
-		$this->assertArrayHasKey( Strings::SUPPORT_TEMPORARILY_UNAVAILABLE, $registry );
+		$this->assertArrayHasKey( Strings::SECURED_BY_TRUSTEDLOGIN, $registry );
+		$this->assertArrayHasKey( Strings::REVOKE_ACCESS, $registry );
+		$this->assertArrayHasKey( Strings::SUPPORT_ACCESS_IS_TEMPORARILY_UNAVAILABLE_PLEASE, $registry );
 		$this->assertArrayHasKey( Strings::TRY_RECONNECTING, $registry );
-		$this->assertArrayHasKey( Strings::CREATED_TIME_AGO, $registry );
+		$this->assertArrayHasKey( Strings::CREATED_1_S_AGO_BY_2, $registry );
 
-		$this->assertSame( 0, $registry[ Strings::SECURED_BY ]['placeholders'] );
-		$this->assertSame( 2, $registry[ Strings::CREATED_TIME_AGO ]['placeholders'] );
+		$this->assertSame( 0, $registry[ Strings::SECURED_BY_TRUSTEDLOGIN ]['placeholders'] );
+		$this->assertSame( 2, $registry[ Strings::CREATED_1_S_AGO_BY_2 ]['placeholders'] );
 	}
 }

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -497,6 +497,116 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 	// ---- Client constructor wires Strings::init -------------------
 
+	// ---- Runtime sprintf safety: closures + filters that produce
+	//      strings with TOO MANY placeholders must NOT crash the SDK
+	//      call site that's about to sprintf with a fixed arg count.
+	//      PHP 8 throws ValueError on "too few arguments" — uncaught
+	//      that's a fatal on the customer's consent screen.
+
+	public function test_closure_returning_too_many_placeholders_falls_back_to_default() {
+		// CREATED_1_S_AGO_BY_2 → SDK call site sprintfs with 2 args.
+		// A closure that returns a string requiring 3 placeholders
+		// would crash sprintf in PHP 8 → must fall back instead.
+		$config = $this->build_config( array(
+			Strings::CREATED_1_S_AGO_BY_2 => static function () {
+				return 'Bad: %s %s %s'; // 3 placeholders, only 2 args supplied
+			},
+		) );
+		Strings::init( $config );
+
+		$resolved = Strings::get(
+			Strings::CREATED_1_S_AGO_BY_2,
+			'Created %1$s ago by %2$s',
+			array( '5min', 'admin' )
+		);
+
+		$this->assertSame(
+			'Created %1$s ago by %2$s',
+			$resolved,
+			'Closure with too many placeholders must fall back to the default; never let sprintf-fatal-producing strings reach the caller.'
+		);
+	}
+
+	public function test_filter_introducing_too_many_placeholders_falls_back_to_default() {
+		Strings::init( $this->build_config() );
+		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN;
+
+		$malicious_filter = static function () {
+			return 'gotcha %s %s %s'; // smuggles placeholders into a 0-placeholder key
+		};
+		add_filter( $tag, $malicious_filter, 10, 1 );
+
+		try {
+			$this->assertSame(
+				'Secured by TrustedLogin',
+				Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			);
+		} finally {
+			remove_filter( $tag, $malicious_filter, 10 );
+		}
+	}
+
+	public function test_closure_returning_fewer_placeholders_is_allowed() {
+		// Returning a fully-formatted string (0 placeholders) for a
+		// 2-placeholder key is the COMMON case — closures usually do
+		// their own sprintf. sprintf with extra args is silent. Allow.
+		$config = $this->build_config( array(
+			Strings::CREATED_1_S_AGO_BY_2 => static function ( $time_ago, $by ) {
+				return "Acme created {$time_ago} ago by {$by}"; // no placeholders left
+			},
+		) );
+		Strings::init( $config );
+
+		$this->assertSame(
+			'Acme created 5min ago by admin',
+			Strings::get(
+				Strings::CREATED_1_S_AGO_BY_2,
+				'Created %1$s ago by %2$s',
+				array( '5min', 'admin' )
+			)
+		);
+	}
+
+	public function test_filter_calling_sprintf_inline_is_allowed() {
+		// Filter can fully format the string itself — should pass
+		// through even though it has 0 placeholders for a placeholder-
+		// having key (caller's sprintf with extra args is silent).
+		Strings::init( $this->build_config() );
+		$tag = 'trustedlogin/strings-test/strings/' . Strings::CREATED_1_S_AGO_BY_2;
+
+		$inline_formatter = static function ( $value, $key, $context ) {
+			return sprintf( $value, $context[0], $context[1] );
+		};
+		add_filter( $tag, $inline_formatter, 10, 4 );
+
+		try {
+			$resolved = Strings::get(
+				Strings::CREATED_1_S_AGO_BY_2,
+				'Created %1$s ago by %2$s',
+				array( '5min', 'admin' )
+			);
+			$this->assertSame( 'Created 5min ago by admin', $resolved );
+		} finally {
+			remove_filter( $tag, $inline_formatter, 10 );
+		}
+	}
+
+	public function test_count_placeholders_handles_format_flags_and_positionals() {
+		// Sanity: count_placeholders should recognize all the common forms.
+		$this->assertSame( 0, Strings::count_placeholders( 'no placeholders here' ) );
+		$this->assertSame( 0, Strings::count_placeholders( 'literal 100%% percent' ) );
+		$this->assertSame( 1, Strings::count_placeholders( '%s alone' ) );
+		$this->assertSame( 2, Strings::count_placeholders( '%s and %d' ) );
+		$this->assertSame( 2, Strings::count_placeholders( '%1$s ... %2$s' ) );
+		$this->assertSame( 3, Strings::count_placeholders( '%1$s ... %3$s (skip %2$s in the middle)' ) );
+		$this->assertSame( 1, Strings::count_placeholders( 'pct %05d' ) );
+		$this->assertSame( 1, Strings::count_placeholders( 'float %.2f' ) );
+		$this->assertSame( 1, Strings::count_placeholders( 'name %-10s' ) );
+		$this->assertSame( 1, Strings::count_placeholders( '100%% real and 1 fake: %s' ) );
+		$this->assertSame( 0, Strings::count_placeholders( null ) );
+		$this->assertSame( 0, Strings::count_placeholders( 42 ) );
+	}
+
 	public function test_client_constructor_initializes_strings() {
 		$client_config_data = array(
 			'auth'   => array( 'api_key' => 'aaaa11112222bbbb' ),

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -316,11 +316,11 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'default' ) );
 	}
 
-	public function test_throwing_closure_propagates_exception() {
-		// Documents the contract: Strings::resolve() does NOT catch
-		// exceptions from integrator closures. If this changes (e.g.
-		// to swallow + fall back to default), the test should be
-		// inverted, not deleted — make the decision explicit.
+	public function test_throwing_closure_falls_back_to_default() {
+		// An integrator closure that throws (DB error, null pointer,
+		// undefined variable) must NOT escape the SDK and fatal the
+		// customer's consent screen. resolve() catches \Throwable
+		// and falls back to the translated default.
 		$config = $this->build_config( array(
 			Strings::SECURED_BY_TRUSTEDLOGIN => static function () {
 				throw new \RuntimeException( 'integrator bug' );
@@ -328,8 +328,44 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		) );
 		Strings::init( $config );
 
-		$this->expectException( \RuntimeException::class );
-		Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'default' );
+		$this->assertSame(
+			'fallback default',
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'fallback default' )
+		);
+	}
+
+	public function test_throwing_filter_does_not_fatal_keeps_resolved_value() {
+		Strings::init( $this->build_config() );
+		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN;
+
+		$thrower = static function () {
+			throw new \RuntimeException( 'integrator filter bug' );
+		};
+		add_filter( $tag, $thrower, 10, 1 );
+
+		try {
+			// Filter throws — get() catches and returns the
+			// pre-filter resolved value (the SDK default).
+			$resolved = Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'safe default' );
+			$this->assertSame( 'safe default', $resolved );
+		} finally {
+			remove_filter( $tag, $thrower, 10 );
+		}
+	}
+
+	public function test_closure_that_throws_error_not_exception_also_falls_back() {
+		// PHP Errors (e.g., calling method on null) extend \Error,
+		// not \Exception. Catch must be \Throwable to cover both.
+		$config = $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => static function () {
+				return ( (object) null )->method_that_does_not_exist();
+			},
+		) );
+		Strings::init( $config );
+
+		// Should NOT throw — catches Error subclass.
+		$resolved = Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'safe default' );
+		$this->assertSame( 'safe default', $resolved );
 	}
 
 	public function test_malformed_override_injected_post_validation_falls_back() {

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -12,6 +12,16 @@ use WP_UnitTestCase;
 
 class TrustedLoginStringsTest extends WP_UnitTestCase {
 
+	public function setUp(): void {
+		parent::setUp();
+		Strings::reset();
+	}
+
+	public function tearDown(): void {
+		Strings::reset();
+		parent::tearDown();
+	}
+
 	private function build_config( array $overrides = array() ): Config {
 		$base = array(
 			'auth'   => array( 'api_key' => '9946ca31be6aa948' ),
@@ -224,5 +234,286 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $registry[ Strings::SECURED_BY_TRUSTEDLOGIN ]['placeholders'] );
 		$this->assertSame( 2, $registry[ Strings::CREATED_1_S_AGO_BY_2 ]['placeholders'] );
+	}
+
+	// =================================================================
+	//  Coverage gaps from the audit pass
+	// =================================================================
+
+	// ---- init() / reset() lifecycle --------------------------------
+
+	public function test_init_called_twice_replaces_bound_config() {
+		Strings::init( $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'First brand',
+		) ) );
+		Strings::init( $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'Second brand',
+		) ) );
+
+		$this->assertSame(
+			'Second brand',
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' ),
+			'A second init() must replace the first binding.'
+		);
+	}
+
+	public function test_get_without_init_returns_default_no_filter() {
+		Strings::reset();
+
+		$filter_fired = false;
+		$spy = static function ( $value ) use ( &$filter_fired ) {
+			$filter_fired = true;
+			return $value;
+		};
+		// Catch ANY trustedlogin strings filter — without init() we
+		// don't know the namespace anyway, but if a filter DOES fire,
+		// the namespace would be 'default' or similar; this catches
+		// the contract violation either way.
+		add_filter( 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN, $spy, 10, 1 );
+
+		try {
+			$this->assertSame(
+				'fallback default',
+				Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'fallback default' )
+			);
+			$this->assertFalse( $filter_fired,
+				'Strings::get() before init() must NOT invoke the runtime filter.' );
+		} finally {
+			remove_filter( 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN, $spy, 10 );
+		}
+	}
+
+	public function test_reset_clears_all_static_state() {
+		Strings::init( $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'X',
+		) ) );
+		Strings::load_translations( 'acme-plugin' );
+
+		Strings::reset();
+
+		$rc = new \ReflectionClass( Strings::class );
+		$prop = static function ( $name ) use ( $rc ) {
+			$p = $rc->getProperty( $name );
+			$p->setAccessible( true );
+			return $p->getValue( null );
+		};
+
+		$this->assertNull( $prop( 'config' ) );
+		$this->assertSame( array(), $prop( 'overrides' ) );
+		$this->assertSame( 'trustedlogin', $prop( 'textdomain' ) );
+		$this->assertFalse( $prop( 'translations_loaded' ) );
+	}
+
+	// ---- get() resolution: closures + bad shapes -------------------
+
+	public function test_zero_arg_closure_override_invoked() {
+		$config = $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => static function () { return 'ZERO-ARG'; },
+		) );
+		Strings::init( $config );
+
+		$this->assertSame( 'ZERO-ARG',
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'default' ) );
+	}
+
+	public function test_throwing_closure_propagates_exception() {
+		// Documents the contract: Strings::resolve() does NOT catch
+		// exceptions from integrator closures. If this changes (e.g.
+		// to swallow + fall back to default), the test should be
+		// inverted, not deleted — make the decision explicit.
+		$config = $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => static function () {
+				throw new \RuntimeException( 'integrator bug' );
+			},
+		) );
+		Strings::init( $config );
+
+		$this->expectException( \RuntimeException::class );
+		Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'default' );
+	}
+
+	public function test_malformed_override_injected_post_validation_falls_back() {
+		// Force an unsupported shape past Config::validate_strings()
+		// by writing it directly into Strings::$overrides via reflection.
+		// This exercises the belt-and-suspenders branch in resolve().
+		Strings::init( $this->build_config() );
+		$rc = new \ReflectionProperty( Strings::class, 'overrides' );
+		$rc->setAccessible( true );
+		$rc->setValue( null, array( Strings::SECURED_BY_TRUSTEDLOGIN => 12345 ) );
+
+		$this->assertSame( 'fallback default',
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'fallback default' ) );
+	}
+
+	// ---- runtime filter -------------------------------------------
+
+	public function test_runtime_filter_receives_four_args() {
+		Strings::init( $this->build_config() );
+		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN;
+
+		$captured = null;
+		$spy = static function ( $value, $key, $context, $config ) use ( &$captured ) {
+			$captured = compact( 'value', 'key', 'context', 'config' );
+			return $value;
+		};
+		add_filter( $tag, $spy, 10, 4 );
+
+		try {
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'X', array( 'ctx' => 'val' ) );
+
+			$this->assertNotNull( $captured );
+			$this->assertSame( 'X', $captured['value'] );
+			$this->assertSame( Strings::SECURED_BY_TRUSTEDLOGIN, $captured['key'] );
+			$this->assertSame( array( 'ctx' => 'val' ), $captured['context'] );
+			$this->assertInstanceOf( Config::class, $captured['config'] );
+		} finally {
+			remove_filter( $tag, $spy, 10 );
+		}
+	}
+
+	public function test_filter_fires_on_override_path() {
+		$config = $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'from-override',
+		) );
+		Strings::init( $config );
+
+		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN;
+		$tag_fired_with = null;
+		$spy = static function ( $value ) use ( &$tag_fired_with ) {
+			$tag_fired_with = $value;
+			return $value;
+		};
+		add_filter( $tag, $spy, 10, 1 );
+
+		try {
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'default' );
+			$this->assertSame( 'from-override', $tag_fired_with,
+				'Filter must see the override value, not the default.' );
+		} finally {
+			remove_filter( $tag, $spy, 10 );
+		}
+	}
+
+	// ---- Config::validate_strings: shape + placeholder edge cases --
+
+	public function test_strings_config_non_array_is_unset() {
+		// Passing a scalar `strings` should be dropped entirely so
+		// the rest of the SDK never sees a non-array shape.
+		$config = new Config( array(
+			'auth'   => array( 'api_key' => '9946ca31be6aa948' ),
+			'vendor' => array(
+				'namespace'   => 'strings-test',
+				'title'       => 'Strings Test',
+				'email'       => 'support@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+			'strings' => 'oops',
+		) );
+		$config->validate();
+
+		$this->assertNull( $config->get_setting( 'strings', null ) );
+	}
+
+	public function test_escaped_percent_does_not_count_toward_placeholder_total() {
+		// CREATED_1_S_AGO_BY_2 requires 2 placeholders. Escaped %%
+		// must not be counted. Override that has 2 real placeholders
+		// AND a literal %% should pass.
+		$config = $this->build_config( array(
+			Strings::CREATED_1_S_AGO_BY_2 => 'Created %1$s ago by %2$s (100%% sure)',
+		) );
+		Strings::init( $config );
+
+		$resolved = Strings::get(
+			Strings::CREATED_1_S_AGO_BY_2,
+			'Created %1$s ago by %2$s',
+			array( '5min', 'admin' )
+		);
+		$this->assertSame( 'Created %1$s ago by %2$s (100%% sure)', $resolved );
+	}
+
+	public function test_format_flags_recognized_as_placeholders() {
+		// %05d / %.2f / %-10s ARE placeholders. For a 0-placeholder
+		// key, an override containing these must be discarded — they
+		// would print raw "%05d" to the customer otherwise.
+		foreach ( array( 'Got %05d sites', 'Uptime %.2f', 'Name %-10s', 'Hex %x', 'Char %c', 'Float %f' ) as $bad_override ) {
+			$config = $this->build_config( array(
+				Strings::SECURED_BY_TRUSTEDLOGIN => $bad_override,
+			) );
+			Strings::init( $config );
+
+			$this->assertSame(
+				'Secured by TrustedLogin',
+				Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' ),
+				sprintf( "Override %s smuggled a placeholder into a 0-placeholder key; should have been discarded.", var_export( $bad_override, true ) )
+			);
+
+			Strings::reset();
+		}
+	}
+
+	/**
+	 * @dataProvider non_string_non_callable_overrides
+	 */
+	public function test_non_string_non_callable_overrides_dropped( $value, string $why ) {
+		$config = $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => $value,
+		) );
+		Strings::init( $config );
+
+		$this->assertSame(
+			'Secured by TrustedLogin',
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' ),
+			$why
+		);
+	}
+
+	public function non_string_non_callable_overrides(): array {
+		return array(
+			'int'             => array( 42, 'int is not a renderable string' ),
+			'float'           => array( 3.14, 'float is not a renderable string' ),
+			'true'            => array( true, 'bool true is not a renderable string' ),
+			'false'           => array( false, 'bool false is not a renderable string' ),
+			'null'            => array( null, 'null collapses to "no override entry" but should not render anything weird' ),
+			'array of string' => array( array( 'one', 'two' ), 'list-shape arrays not supported for non-plural keys' ),
+			'empty array'     => array( array(), 'empty array is not a renderable shape' ),
+		);
+	}
+
+	public function test_mixed_valid_and_invalid_overrides_partial_keep() {
+		$config = $this->build_config( array(
+			Strings::SECURED_BY_TRUSTEDLOGIN => 'Powered by Acme',
+			Strings::CREATED_1_S_AGO_BY_2     => 'I forgot the placeholders',
+		) );
+		Strings::init( $config );
+
+		// Good one preserved.
+		$this->assertSame( 'Powered by Acme',
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' ) );
+		// Bad one falls back to default.
+		$this->assertSame( 'Created %1$s ago by %2$s',
+			Strings::get( Strings::CREATED_1_S_AGO_BY_2, 'Created %1$s ago by %2$s', array( 'x', 'y' ) ) );
+	}
+
+	// ---- Client constructor wires Strings::init -------------------
+
+	public function test_client_constructor_initializes_strings() {
+		$client_config_data = array(
+			'auth'   => array( 'api_key' => 'aaaa11112222bbbb' ),
+			'vendor' => array(
+				'namespace'   => 'client-init-test',
+				'title'       => 'Client Init Test',
+				'email'       => 'support@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+		);
+		$config = new Config( $client_config_data );
+		new Client( $config );
+
+		$rc = new \ReflectionProperty( Strings::class, 'config' );
+		$rc->setAccessible( true );
+		$this->assertSame( $config, $rc->getValue( null ),
+			'Client::__construct must bind the Config to Strings::init().' );
 	}
 }

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Strings + Config::validate_strings() — overrides, placeholder safety,
+ * closure invocation, runtime filter.
+ *
+ * @package TrustedLogin\Client
+ */
+
+namespace TrustedLogin;
+
+use WP_UnitTestCase;
+
+class TrustedLoginStringsTest extends WP_UnitTestCase {
+
+	private function build_config( array $overrides = array() ): Config {
+		$base = array(
+			'auth'   => array( 'api_key' => '9946ca31be6aa948' ),
+			'vendor' => array(
+				'namespace'   => 'strings-test',
+				'title'       => 'Strings Test',
+				'email'       => 'support@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+		);
+		if ( ! empty( $overrides ) ) {
+			$base['strings'] = $overrides;
+		}
+		$config = new Config( $base );
+		$config->validate(); // runs validate_strings() internally
+		return $config;
+	}
+
+	// -----------------------------------------------------------------
+	//  No override → SDK default flows through.
+	// -----------------------------------------------------------------
+
+	public function test_no_override_returns_sdk_default() {
+		$strings = new Strings( $this->build_config() );
+		$this->assertSame(
+			'Secured by TrustedLogin',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  Verbatim string override (the branding case).
+	// -----------------------------------------------------------------
+
+	public function test_string_override_replaces_default() {
+		$config = $this->build_config( array(
+			Strings::SECURED_BY => 'Powered by Acme Support',
+		) );
+
+		$strings = new Strings( $config );
+		$this->assertSame(
+			'Powered by Acme Support',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  Explicit empty string = render nothing (distinct from no override).
+	// -----------------------------------------------------------------
+
+	public function test_explicit_empty_override_renders_empty() {
+		$config = $this->build_config( array(
+			Strings::SECURED_BY => '',
+		) );
+
+		$strings = new Strings( $config );
+		$this->assertSame(
+			'',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  Closure overrides receive $context positional args.
+	// -----------------------------------------------------------------
+
+	public function test_closure_override_receives_context() {
+		$config = $this->build_config( array(
+			Strings::CREATED_TIME_AGO => static function ( $time_ago, $by ) {
+				return "Acme created {$time_ago} ago by {$by}";
+			},
+		) );
+
+		$strings = new Strings( $config );
+		$resolved = $strings->get(
+			Strings::CREATED_TIME_AGO,
+			'Created %1$s ago by %2$s',
+			array( '5 minutes', 'admin' )
+		);
+
+		$this->assertSame( 'Acme created 5 minutes ago by admin', $resolved );
+	}
+
+	// -----------------------------------------------------------------
+	//  Placeholder schema enforcement (#66 critical):
+	//
+	//  CREATED_TIME_AGO expects 2 placeholders. A bad override that
+	//  loses a placeholder must be DISCARDED at validate_strings() time
+	//  so we never sprintf-crash at render.
+	// -----------------------------------------------------------------
+
+	public function test_override_with_missing_placeholder_is_discarded() {
+		$config = $this->build_config( array(
+			Strings::CREATED_TIME_AGO => 'Created at unknown time', // no %1$s %2$s
+		) );
+
+		$strings = new Strings( $config );
+
+		// Override was malformed → discarded → falls through to SDK default.
+		$resolved = $strings->get(
+			Strings::CREATED_TIME_AGO,
+			'Created %1$s ago by %2$s',
+			array( '5 minutes', 'admin' )
+		);
+
+		// The default still contains placeholders; caller would sprintf
+		// it. We only assert the resolution path returns the default
+		// untouched (no crash, no override applied).
+		$this->assertSame( 'Created %1$s ago by %2$s', $resolved );
+	}
+
+	public function test_override_with_extra_placeholder_is_discarded() {
+		// SECURED_BY expects 0 placeholders. Override that smuggles
+		// a %d should be dropped — would print "%d" raw to customers.
+		$config = $this->build_config( array(
+			Strings::SECURED_BY => 'Secured by TL (%d sites protected)',
+		) );
+
+		$strings = new Strings( $config );
+		$this->assertSame(
+			'Secured by TrustedLogin',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	public function test_override_with_escaped_percent_only_accepted_when_no_placeholders_expected() {
+		// `%%` is the literal percent sign — not a real placeholder.
+		// Must pass the safety check.
+		$config = $this->build_config( array(
+			Strings::SECURED_BY => 'Secured by 100%% you',
+		) );
+
+		$strings = new Strings( $config );
+		$this->assertSame(
+			'Secured by 100%% you',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  Unknown keys are silently dropped (forward-compat with future
+	//  SDK versions adding/removing keys).
+	// -----------------------------------------------------------------
+
+	public function test_unknown_key_is_dropped_silently() {
+		$config = $this->build_config( array(
+			'no_such_key' => 'this should never render',
+		) );
+
+		// Reflection-peek to verify the unknown key didn't make it into
+		// the validated set.
+		$strings_setting = $config->get_setting( 'strings', array() );
+		$this->assertArrayNotHasKey( 'no_such_key', $strings_setting );
+	}
+
+	// -----------------------------------------------------------------
+	//  Filter fires AFTER override decision, sees the final candidate.
+	// -----------------------------------------------------------------
+
+	public function test_runtime_filter_can_rewrite_resolved_value() {
+		$config  = $this->build_config();
+		$strings = new Strings( $config );
+
+		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY;
+
+		$rewriter = static function ( $value ) {
+			return strtoupper( $value );
+		};
+		add_filter( $tag, $rewriter, 10, 1 );
+
+		try {
+			$this->assertSame(
+				'SECURED BY TRUSTEDLOGIN',
+				$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+			);
+		} finally {
+			remove_filter( $tag, $rewriter, 10 );
+		}
+	}
+
+	// -----------------------------------------------------------------
+	//  Wrong-shape overrides (objects, mixed arrays) → discarded.
+	// -----------------------------------------------------------------
+
+	public function test_object_override_is_discarded() {
+		$config = $this->build_config( array(
+			Strings::SECURED_BY => new \stdClass(),
+		) );
+
+		$strings = new Strings( $config );
+		$this->assertSame(
+			'Secured by TrustedLogin',
+			$strings->get( Strings::SECURED_BY, 'Secured by TrustedLogin' )
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  registry() exposes the public contract.
+	// -----------------------------------------------------------------
+
+	public function test_registry_includes_every_class_constant() {
+		$registry = Strings::registry();
+
+		$this->assertArrayHasKey( Strings::SECURED_BY, $registry );
+		$this->assertArrayHasKey( Strings::REVOKE_ACCESS_BUTTON, $registry );
+		$this->assertArrayHasKey( Strings::SUPPORT_TEMPORARILY_UNAVAILABLE, $registry );
+		$this->assertArrayHasKey( Strings::TRY_RECONNECTING, $registry );
+		$this->assertArrayHasKey( Strings::CREATED_TIME_AGO, $registry );
+
+		$this->assertSame( 0, $registry[ Strings::SECURED_BY ]['placeholders'] );
+		$this->assertSame( 2, $registry[ Strings::CREATED_TIME_AGO ]['placeholders'] );
+	}
+}

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -41,9 +41,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		return $config;
 	}
 
-	// -----------------------------------------------------------------
-	//  No override → SDK default flows through.
-	// -----------------------------------------------------------------
 
 	public function test_no_override_returns_sdk_default() {
 		Strings::init( $this->build_config() );
@@ -53,9 +50,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		);
 	}
 
-	// -----------------------------------------------------------------
-	//  Verbatim string override (the branding case).
-	// -----------------------------------------------------------------
 
 	public function test_string_override_replaces_default() {
 		$config = $this->build_config( array(
@@ -69,9 +63,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		);
 	}
 
-	// -----------------------------------------------------------------
-	//  Explicit empty string = render nothing (distinct from no override).
-	// -----------------------------------------------------------------
 
 	public function test_explicit_empty_override_renders_empty() {
 		$config = $this->build_config( array(
@@ -85,9 +76,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		);
 	}
 
-	// -----------------------------------------------------------------
-	//  Closure overrides receive $context positional args.
-	// -----------------------------------------------------------------
 
 	public function test_closure_override_receives_context() {
 		$config = $this->build_config( array(
@@ -106,13 +94,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		$this->assertSame( 'Acme created 5 minutes ago by admin', $resolved );
 	}
 
-	// -----------------------------------------------------------------
-	//  Placeholder schema enforcement (#66 critical):
-	//
-	//  CREATED_TIME_AGO expects 2 placeholders. A bad override that
-	//  loses a placeholder must be DISCARDED at validate_strings() time
-	//  so we never sprintf-crash at render.
-	// -----------------------------------------------------------------
 
 	public function test_override_with_missing_placeholder_is_discarded() {
 		$config = $this->build_config( array(
@@ -162,10 +143,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		);
 	}
 
-	// -----------------------------------------------------------------
-	//  Unknown keys are silently dropped (forward-compat with future
-	//  SDK versions adding/removing keys).
-	// -----------------------------------------------------------------
 
 	public function test_unknown_key_is_dropped_silently() {
 		$config = $this->build_config( array(
@@ -178,9 +155,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'no_such_key', $strings_setting );
 	}
 
-	// -----------------------------------------------------------------
-	//  Filter fires AFTER override decision, sees the final candidate.
-	// -----------------------------------------------------------------
 
 	public function test_runtime_filter_can_rewrite_resolved_value() {
 		$config  = $this->build_config();
@@ -203,9 +177,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		}
 	}
 
-	// -----------------------------------------------------------------
-	//  Wrong-shape overrides (objects, mixed arrays) → discarded.
-	// -----------------------------------------------------------------
 
 	public function test_object_override_is_discarded() {
 		$config = $this->build_config( array(
@@ -219,9 +190,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		);
 	}
 
-	// -----------------------------------------------------------------
-	//  registry() exposes the public contract.
-	// -----------------------------------------------------------------
 
 	public function test_registry_includes_every_class_constant() {
 		$registry = Strings::registry();
@@ -236,9 +204,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $registry[ Strings::CREATED_1_S_AGO_BY_2 ]['placeholders'] );
 	}
 
-	// =================================================================
-	//  Coverage gaps from the audit pass
-	// =================================================================
 
 	// ---- init() / reset() lifecycle --------------------------------
 
@@ -350,6 +315,47 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			$this->assertSame( 'safe default', $resolved );
 		} finally {
 			remove_filter( $tag, $thrower, 10 );
+		}
+	}
+
+	public function test_throwing_closure_logs_through_sdk_logging() {
+		// Build a config with logging enabled so the SDK's Logging
+		// surface actually fires its actions.
+		$config = new Config( array(
+			'auth'    => array( 'api_key' => '9946ca31be6aa948' ),
+			'logging' => array( 'enabled' => true ),
+			'vendor'  => array(
+				'namespace'   => 'strings-test',
+				'title'       => 'Strings Test',
+				'email'       => 'support@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+			'strings' => array(
+				Strings::SECURED_BY_TRUSTEDLOGIN => static function () {
+					throw new \RuntimeException( 'integrator bug here' );
+				},
+			),
+		) );
+		$config->validate();
+		Strings::init( $config );
+
+		$captured = array();
+		$spy      = static function ( $message ) use ( &$captured ) {
+			$captured[] = $message;
+		};
+		add_action( 'trustedlogin/strings-test/logging/log_error', $spy, 10, 1 );
+
+		try {
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'safe default' );
+
+			$this->assertNotEmpty( $captured,
+				'A closure that throws must log through the SDK Logging surface.' );
+			$joined = implode( "\n", $captured );
+			$this->assertStringContainsString( 'integrator bug here', $joined );
+			$this->assertStringContainsString( Strings::SECURED_BY_TRUSTEDLOGIN, $joined );
+		} finally {
+			remove_action( 'trustedlogin/strings-test/logging/log_error', $spy, 10 );
 		}
 	}
 

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -359,20 +359,6 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_closure_that_throws_error_not_exception_also_falls_back() {
-		// PHP Errors (e.g., calling method on null) extend \Error,
-		// not \Exception. Catch must be \Throwable to cover both.
-		$config = $this->build_config( array(
-			Strings::SECURED_BY_TRUSTEDLOGIN => static function () {
-				return ( (object) null )->method_that_does_not_exist();
-			},
-		) );
-		Strings::init( $config );
-
-		// Should NOT throw — catches Error subclass.
-		$resolved = Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'safe default' );
-		$this->assertSame( 'safe default', $resolved );
-	}
 
 	public function test_malformed_override_injected_post_validation_falls_back() {
 		// Force an unsupported shape past Config::validate_strings()

--- a/tests/test-strings.php
+++ b/tests/test-strings.php
@@ -36,10 +36,10 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 	// -----------------------------------------------------------------
 
 	public function test_no_override_returns_sdk_default() {
-		$strings = new Strings( $this->build_config() );
+		Strings::init( $this->build_config() );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -52,10 +52,10 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			Strings::SECURED_BY_TRUSTEDLOGIN => 'Powered by Acme Support',
 		) );
 
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 		$this->assertSame(
 			'Powered by Acme Support',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -68,10 +68,10 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			Strings::SECURED_BY_TRUSTEDLOGIN => '',
 		) );
 
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 		$this->assertSame(
 			'',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -86,8 +86,8 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			},
 		) );
 
-		$strings = new Strings( $config );
-		$resolved = $strings->get(
+		Strings::init( $config  );
+		$resolved = Strings::get(
 			Strings::CREATED_1_S_AGO_BY_2,
 			'Created %1$s ago by %2$s',
 			array( '5 minutes', 'admin' )
@@ -109,10 +109,10 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			Strings::CREATED_1_S_AGO_BY_2 => 'Created at unknown time', // no %1$s %2$s
 		) );
 
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 
 		// Override was malformed → discarded → falls through to SDK default.
-		$resolved = $strings->get(
+		$resolved = Strings::get(
 			Strings::CREATED_1_S_AGO_BY_2,
 			'Created %1$s ago by %2$s',
 			array( '5 minutes', 'admin' )
@@ -131,10 +131,10 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			Strings::SECURED_BY_TRUSTEDLOGIN => 'Secured by TL (%d sites protected)',
 		) );
 
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -145,10 +145,10 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			Strings::SECURED_BY_TRUSTEDLOGIN => 'Secured by 100%% you',
 		) );
 
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 		$this->assertSame(
 			'Secured by 100%% you',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 
@@ -174,7 +174,7 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 
 	public function test_runtime_filter_can_rewrite_resolved_value() {
 		$config  = $this->build_config();
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 
 		$tag = 'trustedlogin/strings-test/strings/' . Strings::SECURED_BY_TRUSTEDLOGIN;
 
@@ -186,7 +186,7 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 		try {
 			$this->assertSame(
 				'SECURED BY TRUSTEDLOGIN',
-				$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+				Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 			);
 		} finally {
 			remove_filter( $tag, $rewriter, 10 );
@@ -202,10 +202,10 @@ class TrustedLoginStringsTest extends WP_UnitTestCase {
 			Strings::SECURED_BY_TRUSTEDLOGIN => new \stdClass(),
 		) );
 
-		$strings = new Strings( $config );
+		Strings::init( $config  );
 		$this->assertSame(
 			'Secured by TrustedLogin',
-			$strings->get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
 		);
 	}
 

--- a/tests/test-support-user-locale.php
+++ b/tests/test-support-user-locale.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * #140 — support_user/locale.
+ *
+ * Verifies that:
+ *
+ *   - A configured locale gets written to wp_usermeta during the same
+ *     wp_insert_user() call (not a post-create update_user_meta race).
+ *   - get_user_locale() returns the configured locale for the new user.
+ *   - Malformed locale codes are ignored (site default flows through).
+ *   - The trustedlogin/{ns}/support_user/locale filter can override.
+ *
+ * @package TrustedLogin\Client
+ */
+
+namespace TrustedLogin;
+
+use WP_UnitTestCase;
+
+class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
+
+	private function build_config( array $overrides = array() ): Config {
+		$base = array(
+			'auth'   => array( 'api_key' => '9946ca31be6aa948' ),
+			'role'   => 'editor',
+			'vendor' => array(
+				'namespace'   => 'locale-test',
+				'title'       => 'Locale Test',
+				'email'       => 'support+{hash}@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+		);
+		$base = array_replace_recursive( $base, $overrides );
+		$config = new Config( $base );
+		$config->validate();
+		return $config;
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// On multisite, the support user needs to be granted super-admin
+		// (or at least added to the current blog) for SupportUser::create()
+		// to find the support role. The role-create step itself works
+		// fine on both; this is just so the cap chain resolves.
+		if ( is_multisite() && function_exists( 'grant_super_admin' ) ) {
+			$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+			grant_super_admin( $admin_id );
+			wp_set_current_user( $admin_id );
+		}
+	}
+
+	public function test_configured_locale_lands_on_new_support_user() {
+		$config       = $this->build_config( array(
+			'support_user' => array( 'locale' => 'fr_FR' ),
+		) );
+		$logging      = new Logging( $config );
+		$support_role = new SupportRole( $config, $logging );
+		$support_role->create();
+
+		$support_user = new SupportUser( $config, $logging );
+		$new_user_id  = $support_user->create();
+
+		$this->assertNotInstanceOf( \WP_Error::class, $new_user_id, 'support user creation should succeed' );
+		$this->assertSame( 'fr_FR', get_user_meta( (int) $new_user_id, 'locale', true ) );
+	}
+
+	public function test_malformed_locale_is_ignored() {
+		$config       = $this->build_config( array(
+			'support_user' => array( 'locale' => 'not-a-locale!' ),
+		) );
+		$logging      = new Logging( $config );
+		$support_role = new SupportRole( $config, $logging );
+		$support_role->create();
+
+		$support_user = new SupportUser( $config, $logging );
+		$new_user_id  = $support_user->create();
+
+		$this->assertNotInstanceOf( \WP_Error::class, $new_user_id );
+		// Garbage locale should NOT be written. wp_usermeta has nothing.
+		$this->assertSame( '', (string) get_user_meta( (int) $new_user_id, 'locale', true ) );
+	}
+
+	public function test_filter_can_override_configured_locale() {
+		$config = $this->build_config( array(
+			'support_user' => array( 'locale' => 'de_DE' ),
+		) );
+
+		$swap_to_es = static function () { return 'es_ES'; };
+		add_filter( 'trustedlogin/locale-test/support_user/locale', $swap_to_es, 10, 1 );
+
+		try {
+			$logging      = new Logging( $config );
+			$support_role = new SupportRole( $config, $logging );
+			$support_role->create();
+
+			$support_user = new SupportUser( $config, $logging );
+			$new_user_id  = $support_user->create();
+
+			$this->assertNotInstanceOf( \WP_Error::class, $new_user_id );
+			$this->assertSame( 'es_ES', get_user_meta( (int) $new_user_id, 'locale', true ) );
+		} finally {
+			remove_filter( 'trustedlogin/locale-test/support_user/locale', $swap_to_es, 10 );
+		}
+	}
+
+	public function test_no_locale_setting_leaves_locale_unset() {
+		$config       = $this->build_config(); // no support_user/locale
+		$logging      = new Logging( $config );
+		$support_role = new SupportRole( $config, $logging );
+		$support_role->create();
+
+		$support_user = new SupportUser( $config, $logging );
+		$new_user_id  = $support_user->create();
+
+		$this->assertNotInstanceOf( \WP_Error::class, $new_user_id );
+		$this->assertSame( '', (string) get_user_meta( (int) $new_user_id, 'locale', true ) );
+	}
+
+	// -----------------------------------------------------------------
+	//  Format-only validation accepts unusual but real locales.
+	// -----------------------------------------------------------------
+
+	/**
+	 * @dataProvider valid_locales
+	 */
+	public function test_valid_locale_formats_are_accepted( string $locale ) {
+		$config = $this->build_config( array(
+			'support_user' => array( 'locale' => $locale ),
+		) );
+
+		// Drive the resolver via reflection so we don't have to spin a
+		// full user creation for every locale.
+		$logging      = new Logging( $config );
+		$support_user = new SupportUser( $config, $logging );
+		$rc           = new \ReflectionClass( SupportUser::class );
+		$method       = $rc->getMethod( 'resolve_support_user_locale' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $locale, $method->invoke( $support_user ) );
+	}
+
+	public function valid_locales(): array {
+		return array(
+			'standard de_DE'                 => array( 'de_DE' ),
+			'pt_BR'                          => array( 'pt_BR' ),
+			'WP variant suffix de_DE_formal' => array( 'de_DE_formal' ),
+			'real WP.org locale pt_PT_ao90'  => array( 'pt_PT_ao90' ),
+			'three-letter language ckb'      => array( 'ckb' ),
+			'three-letter w/ region ckb_IQ'  => array( 'ckb_IQ' ),
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  WP locale-resolution behavior: get_user_locale() honors the
+	//  per-user value the SDK wrote. switch_to_user_locale() flips
+	//  the runtime locale to it.
+	// -----------------------------------------------------------------
+
+	public function test_get_user_locale_returns_configured_value() {
+		$user_id = $this->grant_support_user_with_locale( 'fr_FR' );
+
+		$this->assertSame( 'fr_FR', get_user_locale( $user_id ),
+			'get_user_locale() should mirror the wp_usermeta `locale` row the SDK just wrote.' );
+	}
+
+	public function test_get_user_locale_falls_back_to_site_default_when_unset() {
+		$user_id = $this->grant_support_user_with_locale( null );
+
+		// In multisite, the harness blog locale stays at the site default.
+		// We just assert that user-specific locale is NOT set — WP's
+		// normal fallback chain takes over from there.
+		$this->assertSame( '', (string) get_user_meta( $user_id, 'locale', true ) );
+		$this->assertSame( get_locale(), get_user_locale( $user_id ),
+			'With no user-level locale, get_user_locale should fall back to site locale.' );
+	}
+
+	public function test_switch_to_user_locale_activates_set_locale() {
+		if ( ! function_exists( 'switch_to_user_locale' ) ) {
+			$this->markTestSkipped( 'switch_to_user_locale() not available before WP 6.2.' );
+		}
+
+		$user_id = $this->grant_support_user_with_locale( 'de_DE' );
+
+		$this->assertTrue( switch_to_user_locale( $user_id ) );
+		try {
+			$this->assertSame( 'de_DE', determine_locale(),
+				'After switch_to_user_locale, determine_locale should return the user locale.' );
+		} finally {
+			restore_previous_locale();
+		}
+	}
+
+	public function test_multiple_support_users_keep_independent_locales() {
+		$id_a = $this->grant_support_user_with_locale( 'de_DE' );
+
+		// Re-config under a different namespace so we can create a
+		// SECOND support user with a different locale on the same site.
+		$config_b = new Config( array(
+			'auth'         => array( 'api_key' => 'b146ca31be6aa948' ),
+			'role'         => 'editor',
+			'vendor'       => array(
+				'namespace'   => 'locale-test-b',
+				'title'       => 'Locale Test B',
+				'email'       => 'support+b+{hash}@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+			'support_user' => array( 'locale' => 'fr_FR' ),
+		) );
+		$config_b->validate();
+		$logging_b = new Logging( $config_b );
+		( new SupportRole( $config_b, $logging_b ) )->create();
+		$id_b = ( new SupportUser( $config_b, $logging_b ) )->create();
+
+		$this->assertNotInstanceOf( \WP_Error::class, $id_b );
+		$this->assertSame( 'de_DE', get_user_locale( $id_a ) );
+		$this->assertSame( 'fr_FR', get_user_locale( (int) $id_b ) );
+	}
+
+	public function test_locale_persists_across_simulated_logins() {
+		$user_id = $this->grant_support_user_with_locale( 'es_ES' );
+
+		// First "login" — simulate WP loading the user.
+		wp_set_current_user( $user_id );
+		$first = get_user_locale( $user_id );
+		wp_set_current_user( 0 );
+
+		// Drop the user object cache so we re-hydrate from the DB.
+		clean_user_cache( $user_id );
+
+		// Second "login".
+		wp_set_current_user( $user_id );
+		$second = get_user_locale( $user_id );
+
+		$this->assertSame( 'es_ES', $first );
+		$this->assertSame( 'es_ES', $second );
+		$this->assertSame( $first, $second,
+			'The user-locale row should survive cache eviction between sessions.' );
+	}
+
+	// -----------------------------------------------------------------
+	//  Defensive re-assert: when a wp_pre_insert_user_data filter
+	//  strips the `locale` arg before wp_insert_user writes it, the
+	//  SDK still ends up with the requested locale in usermeta.
+	// -----------------------------------------------------------------
+
+	public function test_pre_insert_user_data_filter_stripping_locale_triggers_reassert() {
+		$strip_locale = static function ( $data ) {
+			if ( isset( $data['locale'] ) ) {
+				unset( $data['locale'] );
+			}
+			return $data;
+		};
+		add_filter( 'wp_pre_insert_user_data', $strip_locale, 10, 1 );
+
+		try {
+			$user_id = $this->grant_support_user_with_locale( 'de_DE' );
+
+			// Even though the filter stripped `locale` before insert,
+			// SupportUser::create() detects the mismatch and re-asserts
+			// via update_user_meta(). End-state must match the request.
+			$this->assertSame( 'de_DE', (string) get_user_meta( $user_id, 'locale', true ) );
+		} finally {
+			remove_filter( 'wp_pre_insert_user_data', $strip_locale, 10 );
+		}
+	}
+
+	public function test_filter_returning_empty_string_clears_configured_locale() {
+		$clear = static function () { return ''; };
+		add_filter( 'trustedlogin/locale-test/support_user/locale', $clear, 10, 1 );
+
+		try {
+			$config = $this->build_config( array(
+				'support_user' => array( 'locale' => 'de_DE' ),
+			) );
+			$logging      = new Logging( $config );
+			( new SupportRole( $config, $logging ) )->create();
+			$user_id = ( new SupportUser( $config, $logging ) )->create();
+
+			$this->assertNotInstanceOf( \WP_Error::class, $user_id );
+			$this->assertSame( '', (string) get_user_meta( (int) $user_id, 'locale', true ),
+				'Filter forcing empty should suppress the configured locale entirely.' );
+		} finally {
+			remove_filter( 'trustedlogin/locale-test/support_user/locale', $clear, 10 );
+		}
+	}
+
+	public function test_filter_returning_garbage_is_rejected_by_format_check() {
+		$garbage = static function () { return 'not a real locale!'; };
+		add_filter( 'trustedlogin/locale-test/support_user/locale', $garbage, 10, 1 );
+
+		try {
+			$config = $this->build_config( array(
+				'support_user' => array( 'locale' => 'de_DE' ),
+			) );
+			$logging      = new Logging( $config );
+			( new SupportRole( $config, $logging ) )->create();
+			$user_id = ( new SupportUser( $config, $logging ) )->create();
+
+			$this->assertNotInstanceOf( \WP_Error::class, $user_id );
+			$this->assertSame( '', (string) get_user_meta( (int) $user_id, 'locale', true ),
+				'Garbage from the filter must be format-rejected, leaving locale unset.' );
+		} finally {
+			remove_filter( 'trustedlogin/locale-test/support_user/locale', $garbage, 10 );
+		}
+	}
+
+	// -----------------------------------------------------------------
+	//  Locale variants WordPress.org actually ships with — these
+	//  should all be accepted by resolve_support_user_locale().
+	// -----------------------------------------------------------------
+
+	/**
+	 * @dataProvider invalid_locales
+	 */
+	public function test_malformed_locale_formats_are_rejected( string $locale, string $why ) {
+		$config = $this->build_config( array(
+			'support_user' => array( 'locale' => $locale ),
+		) );
+		$logging      = new Logging( $config );
+		$support_user = new SupportUser( $config, $logging );
+		$rc           = new \ReflectionClass( SupportUser::class );
+		$method       = $rc->getMethod( 'resolve_support_user_locale' );
+		$method->setAccessible( true );
+
+		$this->assertSame( '', $method->invoke( $support_user ), $why );
+	}
+
+	public function invalid_locales(): array {
+		return array(
+			'empty string'                  => array( '', 'no locale requested' ),
+			'whitespace'                    => array( '   ', 'whitespace shouldn\'t pass' ),
+			'shell injection attempt'       => array( 'de_DE; rm -rf /', 'shell-style payload must be rejected' ),
+			'bare language too short'       => array( 'd', 'one-letter language code invalid' ),
+			'wrong-case region'             => array( 'de_de', 'WP locale convention is uppercase region' ),
+			'IETF style with hyphen'        => array( 'de-DE', 'WP uses underscores, not hyphens' ),
+			'path traversal attempt'        => array( '../../etc/passwd', 'no slashes anywhere' ),
+			'angle brackets'                => array( 'de_DE<script>', 'HTML-injection-style payload' ),
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  Helpers
+	// -----------------------------------------------------------------
+
+	/**
+	 * Grant a support user, optionally with a configured locale, and
+	 * return its user ID.
+	 *
+	 * @param string|null $locale Locale string to pin, or null for no
+	 *                            `support_user/locale` config setting.
+	 */
+	private function grant_support_user_with_locale( $locale ): int {
+		$overrides = array();
+		if ( null !== $locale ) {
+			$overrides['support_user'] = array( 'locale' => $locale );
+		}
+		$config       = $this->build_config( $overrides );
+		$logging      = new Logging( $config );
+		( new SupportRole( $config, $logging ) )->create();
+
+		$new_user_id = ( new SupportUser( $config, $logging ) )->create();
+		$this->assertNotInstanceOf( \WP_Error::class, $new_user_id );
+
+		return (int) $new_user_id;
+	}
+}

--- a/tests/test-support-user-locale.php
+++ b/tests/test-support-user-locale.php
@@ -118,9 +118,6 @@ class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
 		$this->assertSame( '', (string) get_user_meta( (int) $new_user_id, 'locale', true ) );
 	}
 
-	// -----------------------------------------------------------------
-	//  Format-only validation accepts unusual but real locales.
-	// -----------------------------------------------------------------
 
 	/**
 	 * @dataProvider valid_locales
@@ -152,11 +149,6 @@ class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
 		);
 	}
 
-	// -----------------------------------------------------------------
-	//  WP locale-resolution behavior: get_user_locale() honors the
-	//  per-user value the SDK wrote. switch_to_user_locale() flips
-	//  the runtime locale to it.
-	// -----------------------------------------------------------------
 
 	public function test_get_user_locale_returns_configured_value() {
 		$user_id = $this->grant_support_user_with_locale( 'fr_FR' );
@@ -240,11 +232,6 @@ class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
 			'The user-locale row should survive cache eviction between sessions.' );
 	}
 
-	// -----------------------------------------------------------------
-	//  Defensive re-assert: when a wp_pre_insert_user_data filter
-	//  strips the `locale` arg before wp_insert_user writes it, the
-	//  SDK still ends up with the requested locale in usermeta.
-	// -----------------------------------------------------------------
 
 	public function test_pre_insert_user_data_filter_stripping_locale_triggers_reassert() {
 		$strip_locale = static function ( $data ) {
@@ -307,10 +294,6 @@ class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
 		}
 	}
 
-	// -----------------------------------------------------------------
-	//  Locale variants WordPress.org actually ships with — these
-	//  should all be accepted by resolve_support_user_locale().
-	// -----------------------------------------------------------------
 
 	/**
 	 * @dataProvider invalid_locales
@@ -341,9 +324,6 @@ class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
 		);
 	}
 
-	// -----------------------------------------------------------------
-	//  Helpers
-	// -----------------------------------------------------------------
 
 	/**
 	 * Grant a support user, optionally with a configured locale, and
@@ -367,9 +347,6 @@ class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
 		return (int) $new_user_id;
 	}
 
-	// =================================================================
-	//  Coverage gaps from the audit pass
-	// =================================================================
 
 	public function test_get_user_locale_does_not_leak_across_current_user_switches() {
 		$id_a = $this->grant_support_user_with_locale( 'de_DE' );

--- a/tests/test-support-user-locale.php
+++ b/tests/test-support-user-locale.php
@@ -366,4 +366,99 @@ class TrustedLoginSupportUserLocaleTest extends WP_UnitTestCase {
 
 		return (int) $new_user_id;
 	}
+
+	// =================================================================
+	//  Coverage gaps from the audit pass
+	// =================================================================
+
+	public function test_get_user_locale_does_not_leak_across_current_user_switches() {
+		$id_a = $this->grant_support_user_with_locale( 'de_DE' );
+
+		// Create a second namespace + user with NO locale set.
+		$config_b = new Config( array(
+			'auth'   => array( 'api_key' => 'b146ca31be6aa948' ),
+			'role'   => 'editor',
+			'vendor' => array(
+				'namespace'   => 'locale-test-no-locale',
+				'title'       => 'Locale Test (no locale)',
+				'email'       => 'support+nl+{hash}@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+		) );
+		$config_b->validate();
+		$logging_b = new Logging( $config_b );
+		( new SupportRole( $config_b, $logging_b ) )->create();
+		$id_b = ( new SupportUser( $config_b, $logging_b ) )->create();
+		$this->assertNotInstanceOf( \WP_Error::class, $id_b );
+
+		// Switch current user to B (no locale) and verify A's locale
+		// is still de_DE — user-locale-per-user is fully independent
+		// of `get_user_locale()` for the current user.
+		wp_set_current_user( (int) $id_b );
+
+		$this->assertSame( 'de_DE', get_user_locale( $id_a ) );
+		$this->assertSame( get_locale(), get_user_locale( (int) $id_b ),
+			'User with no locale meta falls through to site locale, not user A\'s locale.' );
+	}
+
+	public function test_locale_format_check_does_not_consult_get_available_languages() {
+		// Pick a locale that almost certainly isn't installed on the
+		// test box: zz_ZZ. If format-check is the gate (correct), the
+		// locale lands in usermeta. If the SDK consulted
+		// get_available_languages(), the locale would be rejected.
+		$user_id = $this->grant_support_user_with_locale( 'zz_ZZ' );
+
+		$this->assertSame( 'zz_ZZ', (string) get_user_meta( $user_id, 'locale', true ),
+			'Format-only validation must accept unlisted locales — WordPress falls back to English on lookup.' );
+	}
+
+	public function test_en_US_is_accepted_despite_being_absent_from_get_available_languages() {
+		// en_US is never in get_available_languages() (it IS the
+		// default WP installs without a translation pack), but the
+		// SDK must accept it as a legitimate locale request.
+		$user_id = $this->grant_support_user_with_locale( 'en_US' );
+
+		$this->assertSame( 'en_US', (string) get_user_meta( $user_id, 'locale', true ) );
+	}
+
+	public function test_strings_overrides_and_support_user_locale_coexist() {
+		// Cross-feature smoke test: both #66 (strings overrides) and
+		// #140 (support_user/locale) configured in one Config; both
+		// active for the same Client.
+		$config = new Config( array(
+			'auth'         => array( 'api_key' => 'cross1234aabbccdd' ),
+			'role'         => 'editor',
+			'vendor'       => array(
+				'namespace'   => 'cross-feature-test',
+				'title'       => 'Cross Feature Test',
+				'email'       => 'support+cross+{hash}@example.com',
+				'website'     => 'https://vendor.example.com',
+				'support_url' => 'https://vendor.example.com/support',
+			),
+			'support_user' => array( 'locale' => 'fr_FR' ),
+			'strings'      => array(
+				Strings::SECURED_BY_TRUSTEDLOGIN => 'Cross-feature branding',
+			),
+		) );
+		$config->validate();
+		Strings::init( $config );
+
+		// Create the user.
+		$logging = new Logging( $config );
+		( new SupportRole( $config, $logging ) )->create();
+		$user_id = ( new SupportUser( $config, $logging ) )->create();
+
+		// Locale landed.
+		$this->assertNotInstanceOf( \WP_Error::class, $user_id );
+		$this->assertSame( 'fr_FR', get_user_locale( (int) $user_id ) );
+
+		// Override still applies.
+		$this->assertSame(
+			'Cross-feature branding',
+			Strings::get( Strings::SECURED_BY_TRUSTEDLOGIN, 'Secured by TrustedLogin' )
+		);
+
+		Strings::reset();
+	}
 }

--- a/tests/test-translator-comments-extracted.php
+++ b/tests/test-translator-comments-extracted.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Meta-test: every `// translators:` (or block-form) translator
+ * comment authored in src/ must be extracted by `wp i18n make-pot`
+ * into the resulting .pot file as a `#.` extracted comment alongside
+ * its msgid.
+ *
+ * The POT extractor walks the AST looking for gettext calls and pulls
+ * comments that IMMEDIATELY precede each `__()` / `_n()` / `_x()` /
+ * etc. — "immediately" being a small line-proximity window. When call
+ * sites nest the gettext literal deep inside helper wrappers (e.g.
+ * `sprintf( esc_html( Strings::get( Strings::KEY, __( ... ) ) ), ... )`)
+ * a `// translators:` comment placed above the OUTER expression is too
+ * far from the `__()` call and is silently dropped from the POT.
+ *
+ * Translators see `%s` with no guidance → bad translation. This test
+ * catches it at CI time.
+ *
+ * @package TrustedLogin\Client
+ */
+
+namespace TrustedLogin;
+
+use WP_UnitTestCase;
+
+class TrustedLoginTranslatorCommentsExtractedTest extends WP_UnitTestCase {
+
+	/**
+	 * Match either `// translators: ...` line comments or
+	 * `/` + `* translators: ... *` + `/` block comments. Anchored
+	 * at start-of-comment, the same way extractors anchor.
+	 */
+	const COMMENT_RX = '/(?:\/\/|\/\*)\s*translators:\s*(.+?)(?:\*\/|$)/m';
+
+	public function test_every_translator_comment_in_source_is_extracted_into_pot() {
+
+		// 1) Generate a fresh POT from src/. Bin wp-cli is available
+		//    in the tests-cli container.
+		$src_root  = dirname( __DIR__ ) . '/src';
+		$pot_path  = sys_get_temp_dir() . '/trustedlogin-translator-comments.pot';
+		if ( is_file( $pot_path ) ) {
+			unlink( $pot_path );
+		}
+
+		$cmd = sprintf(
+			'wp i18n make-pot %s %s --domain=trustedlogin --slug=trustedlogin --skip-js --skip-audit 2>&1',
+			escapeshellarg( $src_root ),
+			escapeshellarg( $pot_path )
+		);
+		$output = array();
+		$status = 0;
+		exec( $cmd, $output, $status );
+
+		$this->assertSame( 0, $status, "wp i18n make-pot failed: " . implode( "\n", $output ) );
+		$this->assertFileExists( $pot_path );
+
+		$pot = file_get_contents( $pot_path );
+
+		// 2) Walk every PHP source file and collect (file, line,
+		//    comment-text, expected-msgid). We pair each comment
+		//    with the FIRST gettext call that follows it within
+		//    a reasonable proximity (40 lines covers even the
+		//    deeply-wrapped sprintf( esc_html( Strings::get( ... __()))).
+		$source_pairs = $this->scan_source_for_commented_gettext_calls( $src_root );
+
+		$this->assertNotEmpty(
+			$source_pairs,
+			'No translator comments found in src/ — sanity check failed.'
+		);
+
+		// 3) For each pair, assert the POT entry for that msgid
+		//    has a `#.` extracted-comment line containing the
+		//    same translator text.
+		$missing = array();
+		foreach ( $source_pairs as $pair ) {
+			$msgid_block = $this->find_pot_block_for_msgid( $pot, $pair['msgid'] );
+			if ( null === $msgid_block ) {
+				$missing[] = sprintf(
+					"%s:%d (msgid %s) — POT has NO entry at all",
+					$pair['file'],
+					$pair['line'],
+					$this->snip( $pair['msgid'] )
+				);
+				continue;
+			}
+
+			// Normalize whitespace for the contains check — POT
+			// wraps long comments across multiple `#.` lines.
+			$pot_comment_text = preg_replace(
+				'/\s+/',
+				' ',
+				$this->extract_pot_comments( $msgid_block )
+			);
+			$source_comment_text = preg_replace( '/\s+/', ' ', $pair['comment'] );
+
+			// Require a substantive overlap. The extractor sometimes
+			// wraps lines mid-word; matching on the first ~30 chars
+			// of the source comment is the safest signal.
+			$needle = trim( substr( $source_comment_text, 0, 30 ) );
+			if ( '' === $needle ) {
+				continue; // empty `translators:` is harmless
+			}
+			if ( false === strpos( $pot_comment_text, $needle ) ) {
+				$missing[] = sprintf(
+					"%s:%d (msgid %s)\n      source comment: %s\n      POT #. lines: %s",
+					$pair['file'],
+					$pair['line'],
+					$this->snip( $pair['msgid'] ),
+					$this->snip( $source_comment_text ),
+					'' === $pot_comment_text ? '(none)' : $this->snip( $pot_comment_text )
+				);
+			}
+		}
+
+		$this->assertEmpty(
+			$missing,
+			"Translator comments in src/ that did NOT land in the POT:\n  - "
+			. implode( "\n  - ", $missing )
+			. "\nFix: move the `// translators:` comment so it immediately"
+			. " precedes the `__()` literal — `wp i18n make-pot` doesn't"
+			. " scan more than a few lines back."
+		);
+	}
+
+	// -----------------------------------------------------------------
+	//  Helpers
+	// -----------------------------------------------------------------
+
+	/**
+	 * @return list<array{file: string, line: int, comment: string, msgid: string}>
+	 */
+	private function scan_source_for_commented_gettext_calls( string $src_root ): array {
+		$out = array();
+		$files = glob( $src_root . '/*.php' );
+
+		foreach ( $files as $path ) {
+			$rel = basename( $path );
+			if ( 'Strings.php' === $rel ) {
+				continue; // class docblock contains example __() in comments
+			}
+
+			$contents = file_get_contents( $path );
+			$lines    = explode( "\n", $contents );
+			$n        = count( $lines );
+
+			for ( $i = 0; $i < $n; $i++ ) {
+				if ( ! preg_match( self::COMMENT_RX, $lines[ $i ], $cm, PREG_OFFSET_CAPTURE ) ) {
+					continue;
+				}
+				$comment = trim( $cm[1][0] );
+				if ( '' === $comment ) {
+					continue;
+				}
+				$comment_offset_on_line = $cm[0][1];
+
+				$msgid      = null;
+				$found_line = null;
+				$gettext_rx = '/(?:esc_html__|esc_attr__|__|_e|_n|_x|_nx|esc_html_x|esc_attr_x)\s*\(\s*([\x27"])((?:\\\\.|(?!\1).)*?)\1/';
+
+				// 1) Inline case: comment and gettext are on the same
+				//    line. Search the substring AFTER the comment for a
+				//    gettext call. This is the canonical placement when
+				//    using block-form `/* translators: */ __(...)`.
+				$rest_of_line = substr( $lines[ $i ], $comment_offset_on_line );
+				if ( preg_match( $gettext_rx, $rest_of_line, $gm ) ) {
+					$quote = $gm[1];
+					$msgid = $quote === "'"
+						? str_replace( array( "\\'", "\\\\" ), array( "'", "\\" ), $gm[2] )
+						: stripcslashes( $gm[2] );
+					$found_line = $i + 1;
+				}
+
+				// 2) Otherwise look forward up to 40 lines for the next
+				//    gettext call (the multi-line placement pattern).
+				if ( null === $msgid ) {
+					for ( $j = $i + 1; $j < min( $n, $i + 40 ); $j++ ) {
+						if ( preg_match( $gettext_rx, $lines[ $j ], $gm ) ) {
+							$quote = $gm[1];
+							$msgid = $quote === "'"
+								? str_replace( array( "\\'", "\\\\" ), array( "'", "\\" ), $gm[2] )
+								: stripcslashes( $gm[2] );
+							$found_line = $j + 1;
+							break;
+						}
+					}
+				}
+				if ( null === $msgid ) {
+					continue;
+				}
+
+				$out[] = array(
+					'file'    => $rel,
+					'line'    => $i + 1,
+					'comment' => $comment,
+					'msgid'   => $msgid,
+				);
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Returns the POT block (preceding metadata + msgid + msgstr)
+	 * for $msgid, or null if absent.
+	 */
+	private function find_pot_block_for_msgid( string $pot, string $msgid ): ?string {
+		// POT msgids escape backslashes and double-quotes.
+		$escaped = addcslashes( $msgid, "\\\"" );
+
+		// Match: (optional preceding metadata lines like #. #: #,)
+		// followed by msgid "..." then msgstr "".
+		$pat = '/(?:^[#].*\n)*msgid\s+"' . preg_quote( $escaped, '/' ) . '"\s*\nmsgstr/m';
+		if ( preg_match( $pat, $pot, $m, PREG_OFFSET_CAPTURE ) ) {
+			return $m[0][0];
+		}
+
+		// Long msgids that span multiple lines via `"...\n"` continuation.
+		// Cheap fallback: find any msgid containing this string.
+		$lines = explode( "\n", $pot );
+		foreach ( $lines as $idx => $line ) {
+			if ( 0 === strpos( $line, 'msgid "' ) && false !== strpos( $line, $escaped ) ) {
+				// Walk backwards to collect preceding `#.` / `#:` / `#,` lines.
+				$start = $idx;
+				while ( $start > 0 && 0 === strpos( $lines[ $start - 1 ], '#' ) ) {
+					$start--;
+				}
+				return implode( "\n", array_slice( $lines, $start, $idx - $start + 2 ) );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Pull `#.` extracted-comment text from a POT entry block.
+	 */
+	private function extract_pot_comments( string $block ): string {
+		$out = array();
+		foreach ( explode( "\n", $block ) as $line ) {
+			if ( 0 === strpos( $line, '#.' ) ) {
+				$out[] = trim( substr( $line, 2 ) );
+			}
+		}
+		return implode( ' ', $out );
+	}
+
+	private function snip( string $s, int $len = 70 ): string {
+		$s = trim( preg_replace( '/\s+/', ' ', $s ) );
+		return strlen( $s ) > $len ? substr( $s, 0, $len - 1 ) . '…' : $s;
+	}
+}


### PR DESCRIPTION
## Summary

Adds two long-standing i18n capabilities to the SDK:

- **Integrator string overrides** (closes #66) — a new `Strings` class exposes every user-facing SDK string as a stable constant. Integrators can override any string verbatim, with an empty value, or with a closure (for context-dependent variants) via the `strings` Config key. Strauss-safe: each prefixed SDK image gets its own filter namespace, so overrides never collide across plugins that ship the SDK.
- **Per-user locale for the created support user** (closes #140) — new `support_user/locale` config + `trustedlogin/{ns}/support_user/locale` filter. Locale is written through `wp_insert_user`'s `locale` arg (WP 4.7+) and defensively re-asserted via `update_user_meta` to survive `wp_insert_user` ignoring the arg in some scenarios.

The 117 user-facing strings in `src/Form.php`, `src/Remote.php`, `src/SupportUser.php`, `src/Admin.php`, etc. were migrated to route through `Strings::get(Strings::KEY, __('English', 'trustedlogin'))`. The literal `__()` is the anchor `wp i18n make-pot` extracts; `Strings::get()` then re-translates against whichever textdomain the integrator routed via `Strings::load_translations()`.

## Why this shape

- **`Strings::get()` is static** — no per-class plumbing. Call sites read like `Strings::get(Strings::SECURED_BY_TRUSTEDLOGIN, __( 'Secured by TrustedLogin', 'trustedlogin' ))`.
- **Closure overrides are safe** — `try { … } catch ( \Exception $e )` around every integrator callback + filter, routed through the SDK's own `Logging` surface. PHP 5.3 target rules out `\Throwable`, so `\Error` from integrator code is not caught (accepted trade-off).
- **`sprintf` "too few args" guard** — `Strings::count_placeholders()` checks the resolved string against the registry's declared placeholder budget. If a closure/filter inflates the placeholder count, we fall back to the SDK default rather than letting a `ValueError` reach the caller's `sprintf`.
- **`Config::validate_strings()`** uses a sentinel-based `vsprintf` test (`placeholders_safe()`) to reject overrides whose placeholder layout doesn't match the SDK default — so an override of `'Extend %1$s Access for %2$s'` with `'Extend %s Access'` is rejected at config time, not at render time.

## Test coverage

- **216 tests / 759 assertions, all passing.**
- `tests/test-strings.php` — Strings API (init/reset/registry/known_keys/get/resolve/count_placeholders), every override shape (null / empty / string / closure), `placeholders_safe()` edge cases.
- `tests/test-strings-translation.php` — translation routing against the integrator's textdomain, switch-locale behaviour, pre-init deferral.
- `tests/test-support-user-locale.php` — explicit locale, filter, fallback to site locale, defensive re-assert.
- `tests/test-translator-comments-extracted.php` — **meta-test** that runs `wp i18n make-pot` and verifies every `// translators:` comment in `src/` reaches the resulting POT. Catches the WP-CLI extractor's proximity rule at CI time.

## Quality gates

- PHPCS (`.phpcs.xml.dist`, `testVersion: 5.3-`) — clean
- PHPStan (`phpVersion: 70400`) — clean
- PHPUnit (multisite) — 216 / 216

## Notes for review

- `AGENTS.md` has a new **Comment Discipline** section documenting the PHP 5.3 runtime target and the rule against meta-narrative / task-reference comments.
- `tests/test-translator-comments-extracted.php` is a meta-test, not a unit test — it shells out to `wp i18n make-pot` and runs only in the `tests-cli` container. It should be kept in CI.

Closes #66
Closes #140

## Test plan

- [ ] PHPCS clean (`composer lint`)
- [ ] PHPStan clean (`composer phpstan`)
- [ ] PHPUnit clean (`npx wp-env run tests-cli --env-cwd=wp-content/plugins/client composer test`)
- [ ] Manual: integrator override of a non-placeholder string (e.g. `Strings::SECURED_BY_TRUSTEDLOGIN`) renders verbatim
- [ ] Manual: integrator override of a placeholder string with wrong arg count is rejected by `Config::validate_strings()` at construction
- [ ] Manual: `support_user/locale` set to `de_DE` produces a support user whose admin UI is German
- [ ] Manual: `change_locale` on a running site reloads the SDK's `.mo` correctly